### PR TITLE
Allow override of environment variables

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -199,9 +199,54 @@ Only accessible from the command line interface, this option sets the verbosity
 of the console output. When verbose is enabled then [action][] messages will be
 displayed in addition to log messages specified by the [severity][] level.
 
+# Environment Variables
+
+Environment variables like `TEXINPUTS` maybe set in any options file by
+prefixing the variable with a `$`. For instance, the following YAML file will
+set the environment variable `FOO` to the value of `bar`.
+
+```yaml
+$FOO: bar
+```
+
+Environment variables may refer to system level environment variables also. For
+example the following will prefix the system search path with `/foo/bar`.
+
+```yaml
+$PATH: /foo/bar:$PATH
+```
+
+Path resolution (as detailed in [cleanPatterns][]) may also be done on
+environment variable values by using arrays. For instance, the following will
+set `TEXINPUTS` to `/baz:/baz/output:` if the current file path is
+`/baz/gronk.tex`.
+
+```yaml
+outputDirectory: output
+$TEXINPUTS:
+  - $ROOTDIR
+  - $ROOTDIR/$OUTDIR
+  -
+```
+
+Kpathsea compliant TeX distributions typically use a trailing empty path to
+indicate that the system default search path should be appended to the search
+path specified by the environment variable. This convention can also be used
+to set the system search path. The final item will be replaced with the value
+of `PATH` (`Path` on Windows) from the system environment.
+
+```yaml
+outputDirectory: output
+$PATH:
+  - $ROOTDIR
+  - $ROOTDIR/$OUTDIR
+  -
+```
+
 [action]: events#action
 [build]: commands#build
 [clean]: commands#clean
+[cleanPatterns]: #cleanPatterns
 [copyTargetsToRoot]: #copytargetstoroot
 [DviToPdf]: rules#dvitopdf
 [engine]: #engine

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -99,6 +99,9 @@ program
 Dicy.getOptionDefinitions().then(definitions => {
   function loadOptions (pc) {
     for (const option of definitions) {
+      // Skip environment variables
+      if (option.name.startsWith('$')) continue
+
       const commands = pc.name().split(',')
 
       if (!option.commands.some(command => commands.includes(command))) continue

--- a/packages/core/resources/option-schema.yaml
+++ b/packages/core/resources/option-schema.yaml
@@ -140,3 +140,67 @@ synctex:
   defaultValue: false
   commands:
     - build
+PATH:
+  aliases:
+    - texPath
+  description: search path for executables
+  type: strings
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+BIBINPUTS:
+  description: BibTeX bibliography source search path
+  type: strings
+  defaultValue:
+    - .
+    - $OUTDIR
+    -
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+BSTINPUTS:
+  description: BibTeX style file search path
+  type: strings
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+TEXPICTS:
+  description: Picture search path
+  type: strings
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+MFINPUTS:
+  description: Metafont source search path
+  type: strings
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+TEXINPUTS:
+  description: TeX source search path
+  type: strings
+  defaultValue:
+    - .
+    - $OUTDIR
+    -
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub

--- a/packages/core/resources/option-schema.yaml
+++ b/packages/core/resources/option-schema.yaml
@@ -155,9 +155,18 @@ BIBINPUTS:
   description: BibTeX bibliography source search path
   type: strings
   defaultValue:
-    - .
-    - $OUTDIR
+    - $ROOTDIR
+    - $ROOTDIR/$OUTDIR
     -
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+BLTXMLINPUTS:
+  description: BibLaTeXML bibliography files for Biber search path
+  type: strings
   commands:
     - build
     - clean
@@ -166,6 +175,15 @@ BIBINPUTS:
     - scrub
 BSTINPUTS:
   description: BibTeX style file search path
+  type: strings
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+CLUAINPUTS:
+  description: Dynamic libraries for Lua search path
   type: strings
   commands:
     - build
@@ -182,8 +200,26 @@ TEXPICTS:
     - graph
     - log
     - scrub
+LUAINPUTS:
+  description: Lua source search path
+  type: strings
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
 MFINPUTS:
   description: Metafont source search path
+  type: strings
+  commands:
+    - build
+    - clean
+    - graph
+    - log
+    - scrub
+MPINPUTS:
+  description: MetaPont source search path
   type: strings
   commands:
     - build
@@ -195,8 +231,8 @@ TEXINPUTS:
   description: TeX source search path
   type: strings
   defaultValue:
-    - .
-    - $OUTDIR
+    - $ROOTDIR
+    - $ROOTDIR/$OUTDIR
     -
   commands:
     - build

--- a/packages/core/resources/option-schema.yaml
+++ b/packages/core/resources/option-schema.yaml
@@ -143,6 +143,7 @@ synctex:
 $PATH:
   aliases:
     - texPath
+    - $Path
   description: search path for executables
   type: strings
   commands:

--- a/packages/core/resources/option-schema.yaml
+++ b/packages/core/resources/option-schema.yaml
@@ -140,7 +140,7 @@ synctex:
   defaultValue: false
   commands:
     - build
-PATH:
+$PATH:
   aliases:
     - texPath
   description: search path for executables
@@ -151,7 +151,7 @@ PATH:
     - graph
     - log
     - scrub
-BIBINPUTS:
+$BIBINPUTS:
   description: BibTeX bibliography source search path
   type: strings
   defaultValue:
@@ -164,7 +164,7 @@ BIBINPUTS:
     - graph
     - log
     - scrub
-BLTXMLINPUTS:
+$BLTXMLINPUTS:
   description: BibLaTeXML bibliography files for Biber search path
   type: strings
   commands:
@@ -173,7 +173,7 @@ BLTXMLINPUTS:
     - graph
     - log
     - scrub
-BSTINPUTS:
+$BSTINPUTS:
   description: BibTeX style file search path
   type: strings
   commands:
@@ -182,7 +182,7 @@ BSTINPUTS:
     - graph
     - log
     - scrub
-CLUAINPUTS:
+$CLUAINPUTS:
   description: Dynamic libraries for Lua search path
   type: strings
   commands:
@@ -191,7 +191,7 @@ CLUAINPUTS:
     - graph
     - log
     - scrub
-TEXPICTS:
+$TEXPICTS:
   description: Picture search path
   type: strings
   commands:
@@ -200,7 +200,7 @@ TEXPICTS:
     - graph
     - log
     - scrub
-LUAINPUTS:
+$LUAINPUTS:
   description: Lua source search path
   type: strings
   commands:
@@ -209,7 +209,7 @@ LUAINPUTS:
     - graph
     - log
     - scrub
-MFINPUTS:
+$MFINPUTS:
   description: Metafont source search path
   type: strings
   commands:
@@ -218,7 +218,7 @@ MFINPUTS:
     - graph
     - log
     - scrub
-MPINPUTS:
+$MPINPUTS:
   description: MetaPont source search path
   type: strings
   commands:
@@ -227,7 +227,7 @@ MPINPUTS:
     - graph
     - log
     - scrub
-TEXINPUTS:
+$TEXINPUTS:
   description: TeX source search path
   type: strings
   defaultValue:

--- a/packages/core/spec/DicySpec.js
+++ b/packages/core/spec/DicySpec.js
@@ -29,7 +29,7 @@ describe('Dicy', () => {
     done()
   })
 
-  it('can successfully build', () => {
+  describe('can successfully build', () => {
     for (const name of tests) {
       const spec = it(name, async (done) => {
         let expected = { types: [], events: [] }

--- a/packages/core/src/Dicy.js
+++ b/packages/core/src/Dicy.js
@@ -16,10 +16,8 @@ export default class Dicy extends StateConsumer {
     const state = await State.create(filePath, schema)
     const builder = new Dicy(state)
 
-    const instance = await state.getFile('dicy-instance.yaml-ParsedYAML')
-    if (instance) instance.value = options
-
     await builder.initialize()
+    await builder.setInstanceOptions(options)
 
     return builder
   }
@@ -29,6 +27,11 @@ export default class Dicy extends StateConsumer {
     const entries: Array<string> = await readdir.async(ruleClassPath)
     this.state.ruleClasses = entries
       .map(entry => require(path.join(ruleClassPath, entry)).default)
+  }
+
+  async setInstanceOptions (options: Object = {}) {
+    const instance = await this.getFile('dicy-instance.yaml-ParsedYAML')
+    if (instance) instance.value = options
   }
 
   async analyzePhase (command: Command, phase: Phase) {

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -332,7 +332,7 @@ export default class Rule extends StateConsumer {
 
         processOptions.env[envName] = paths.join(path.delimiter)
       } else {
-        processOptions.env[envName] = value
+        processOptions.env[envName] = this.expandVariables(value)
       }
     }
 

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -320,8 +320,12 @@ export default class Rule extends StateConsumer {
     }
     const searchOptionNames = [
       'BIBINPUTS',
+      'BLTXMLINPUTS',
       'BSTINPUTS',
+      'CLUAINPUTS',
+      'LUAINPUTS',
       'MFINPUTS',
+      'MPINPUTS',
       'PATH',
       'TEXINPUTS',
       'TEXPICTS'

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -318,30 +318,20 @@ export default class Rule extends StateConsumer {
       cwd: this.rootPath,
       env: Object.assign({}, process.env)
     }
-    const searchOptionNames = [
-      'BIBINPUTS',
-      'BLTXMLINPUTS',
-      'BSTINPUTS',
-      'CLUAINPUTS',
-      'LUAINPUTS',
-      'MFINPUTS',
-      'MPINPUTS',
-      'PATH',
-      'TEXINPUTS',
-      'TEXPICTS'
-    ]
 
-    for (const name of searchOptionNames) {
-      const value: ?Array<string> = this.options[name]
-      if (value && value !== ['']) {
+    for (const [name, value] of this.state.getOptions(this.jobName)) {
+      if (!name.startsWith('$')) continue
+      const envName = (process.platform === 'win32' && name === '$PATH') ? 'Path' : name.substring(1)
+      if (Array.isArray(value)) {
         const paths: Array<string> = value.map(filePath => filePath ? this.resolvePath(filePath) : '')
-        const envName = process.platform === 'win32' && name === 'PATH' ? 'Path' : name
 
         if (processOptions.env[envName] && paths.length > 0 && paths[paths.length - 1] === '') {
           paths[paths.length - 1] = processOptions.env[envName]
         }
 
         processOptions.env[envName] = paths.join(path.delimiter)
+      } else {
+        processOptions.env[envName] = value
       }
     }
 

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -313,10 +313,37 @@ export default class Rule extends StateConsumer {
   }
 
   constructProcessOptions (): Object {
-    return {
+    const processOptions = {
       cwd: this.rootPath,
       env: Object.assign({}, process.env)
     }
+    const searchOptionNames = [
+      'BIBINPUTS',
+      'BSTINPUTS',
+      'MFINPUTS',
+      'PATH',
+      'TEXINPUTS',
+      'TEXPICTS'
+    ]
+
+    for (const name of searchOptionNames) {
+      const value: ?Array<string> = this.options[name]
+      if (value && value !== ['']) {
+        const paths: Array<string> = value.map(filePath => filePath ? this.resolvePath(filePath) : '')
+
+        if (processOptions.env[name] && paths.length > 0 && paths[paths.length - 1] === '') {
+          paths[paths.length - 1] = processOptions.env[name]
+        }
+
+        if (process.platform === 'win32' && name === 'PATH') {
+          processOptions.env['Path'] = paths.join(';')
+        } else {
+          processOptions.env[name] = paths.join(':')
+        }
+      }
+    }
+
+    return processOptions
   }
 
   constructCommand (): Array<string> {

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -323,7 +323,8 @@ export default class Rule extends StateConsumer {
       if (!name.startsWith('$')) continue
       const envName = (process.platform === 'win32' && name === '$PATH') ? 'Path' : name.substring(1)
       if (Array.isArray(value)) {
-        const paths: Array<string> = value.map(filePath => filePath ? this.resolvePath(filePath) : '')
+        const emptyPath = (name === '$PATH') ? process.env[envName] : ''
+        const paths: Array<string> = value.map(filePath => filePath ? this.resolvePath(filePath) : emptyPath)
 
         if (processOptions.env[envName] && paths.length > 0 && paths[paths.length - 1] === '') {
           paths[paths.length - 1] = processOptions.env[envName]

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import path from 'path'
 import commandJoin from 'command-join'
 
 import State from './State'
@@ -330,16 +331,13 @@ export default class Rule extends StateConsumer {
       const value: ?Array<string> = this.options[name]
       if (value && value !== ['']) {
         const paths: Array<string> = value.map(filePath => filePath ? this.resolvePath(filePath) : '')
+        const envName = process.platform === 'win32' && name === 'PATH' ? 'Path' : name
 
-        if (processOptions.env[name] && paths.length > 0 && paths[paths.length - 1] === '') {
-          paths[paths.length - 1] = processOptions.env[name]
+        if (processOptions.env[envName] && paths.length > 0 && paths[paths.length - 1] === '') {
+          paths[paths.length - 1] = processOptions.env[envName]
         }
 
-        if (process.platform === 'win32' && name === 'PATH') {
-          processOptions.env['Path'] = paths.join(';')
-        } else {
-          processOptions.env[name] = paths.join(':')
-        }
+        processOptions.env[envName] = paths.join(path.delimiter)
       }
     }
 

--- a/packages/core/src/Rules/Asymptote.js
+++ b/packages/core/src/Rules/Asymptote.js
@@ -29,10 +29,10 @@ export default class Asymptote extends Rule {
   }
 
   constructProcessOptions (): Object {
-    return {
+    return Object.assign(super.constructProcessOptions(), {
       maxBuffer: 524288,
       cwd: this.resolvePath('$ROOTDIR/$DIR', this.firstParameter)
-    }
+    })
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/BibTeX.js
+++ b/packages/core/src/Rules/BibTeX.js
@@ -47,18 +47,6 @@ export default class BibTeX extends Rule {
     if (!this.input) this.actions.delete('run')
   }
 
-  constructProcessOptions () {
-    const options: Object = {
-      cwd: this.rootPath
-    }
-
-    if (this.options.outputDirectory) {
-      options.env = Object.assign({}, process.env, { BIBINPUTS: ['.', this.options.outputDirectory].join(path.delimiter) })
-    }
-
-    return options
-  }
-
   constructCommand () {
     return ['bibtex', this.input ? this.input.filePath : '']
   }

--- a/packages/core/src/Rules/LaTeX.js
+++ b/packages/core/src/Rules/LaTeX.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import path from 'path'
-
 import State from '../State'
 import File from '../File'
 import Rule from '../Rule'
@@ -46,22 +44,6 @@ export default class LaTeX extends Rule {
     await this.getResolvedInput('$OUTDIR/$JOB.aux')
     await this.getResolvedOutputs(['$OUTDIR/$JOB.aux', '$OUTDIR/$JOB.fls', '$OUTDIR/$JOB.log', '$OUTDIR/$JOB.synctex.gz'])
     return true
-  }
-
-  constructProcessOptions (): Object {
-    const options = super.constructProcessOptions()
-
-    if (this.options.outputDirectory) {
-      const paths = [
-        path.resolve(this.rootPath, this.options.outputDirectory),
-        ''
-      ]
-
-      if (options.env.TEXINPUTS) paths.unshift(options.env.TEXINPUTS)
-      options.env.TEXINPUTS = paths.join(':')
-    }
-
-    return options
   }
 
   constructCommand () {

--- a/packages/core/src/Rules/MetaPost.js
+++ b/packages/core/src/Rules/MetaPost.js
@@ -14,9 +14,9 @@ export default class MetaPost extends Rule {
   }
 
   constructProcessOptions (): Object {
-    return {
+    return Object.assign(super.constructProcessOptions(), {
       cwd: this.resolvePath('$ROOTDIR/$DIR', this.firstParameter)
-    }
+    })
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/Sage.js
+++ b/packages/core/src/Rules/Sage.js
@@ -13,11 +13,9 @@ export default class Sage extends Rule {
   }
 
   constructProcessOptions (): Object {
-    return {
-      cwd: this.options.outputDirectory
-        ? path.resolve(this.rootPath, this.options.outputDirectory)
-        : this.rootPath
-    }
+    return Object.assign(super.constructProcessOptions(), {
+      cwd: this.resolvePath('$ROOTDIR/$OUTDIR')
+    })
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/State.js
+++ b/packages/core/src/State.js
@@ -36,12 +36,18 @@ export default class State extends EventEmitter {
       if (option.defaultValue) this.defaultOptions[option.name] = option.defaultValue
     }
     this.assignOptions(this.defaultOptions)
-    this.env = {
-      HOME: process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'],
+
+    this.env = Object.assign({}, process.env, {
       DIR: dir,
       BASE: base,
       NAME: name,
       EXT: ext
+    })
+    if (process.platform === 'win32') {
+      Object.assign(this.env, {
+        HOME: process.env.USERPROFILE,
+        PATH: process.env.Path
+      })
     }
   }
 

--- a/packages/core/src/State.js
+++ b/packages/core/src/State.js
@@ -194,16 +194,14 @@ export default class State extends EventEmitter {
       if (from.hasOwnProperty(name)) {
         const value = from[name]
         if (typeof value !== 'object' || Array.isArray(value)) {
-          if (name.startsWith('$')) {
-            // Its an environment variable
+          const schema = this.optionSchema.get(name)
+          if (schema) {
+            to[schema.name] = value
+          } else if (name.startsWith('$')) {
+            // It's an environment variable
             to[name] = value
           } else {
-            const schema = this.optionSchema.get(name)
-            if (schema) {
-              to[schema.name] = value
-            } else {
-              // Tell somebody!
-            }
+            // Tell somebody!
           }
         } else {
           if (!(name in to)) to[name] = {}

--- a/packages/core/src/StateConsumer.js
+++ b/packages/core/src/StateConsumer.js
@@ -116,7 +116,7 @@ export default class StateConsumer {
       })
     }
 
-    return path.normalize(filePath.replace(VARIABLE_PATTERN, (match, name) => properties[name]))
+    return path.normalize(filePath.replace(VARIABLE_PATTERN, (match, name) => properties[name] || match[0]))
   }
 
   async globPath (pattern: string, reference?: File | string, { types = 'all', ignorePattern }: globOptions = {}): Promise<Array<string>> {


### PR DESCRIPTION
Any environment variable can specified by prefixing it with a `$`. For instance:

```yaml
$FOO: bar
```

If  the value is an array then path expansion (like `cleanPatterns`) will be used:

```yaml
$BIBINPUTS:
  - foo
  - $OUTDIR
  -
```

will result in `BIBINPUTS=foo;output;` on Windows,

## References

- [Kpathsea](https://tug.org/texinfohtml/kpathsea.html#Supported-file-formats-1)
- [MiKTeX](https://docs.miktex.org/manual/envvars.html)