### PR TITLE
Improve bailout response to rule failure and kill command

### DIFF
--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -83,6 +83,9 @@ const command = async (inputs, env) => {
       dicy.on(type, event => { events.push(event) })
     }
 
+    process.on('SIGTERM', () => dicy.kill())
+    process.on('SIGINT', () => dicy.kill())
+
     await dicy.run(...commands)
 
     if (saveEvents.length !== 0) {
@@ -93,7 +96,7 @@ const command = async (inputs, env) => {
 }
 
 program
-  .version('0.0.0')
+  .version('0.1.0')
   .description('An experimental circular builder for LaTeX')
 
 DiCy.getOptionDefinitions().then(definitions => {

--- a/packages/core/src/DiCy.js
+++ b/packages/core/src/DiCy.js
@@ -162,15 +162,21 @@ export default class DiCy extends StateConsumer {
   }
 
   kill (message: string = 'Build was killed.'): Promise<void> {
-    return new Promise(resolve => {
-      this.killToken = {
-        error: new Error(message),
-        resolve
-      }
+    if (this.killToken) return this.killToken.promise
+
+    this.killToken = {
+      error: new Error(message)
+    }
+    // $FlowIgnore
+    this.killToken.promise = new Promise(resolve => {
+      // $FlowIgnore
+      this.killToken.resolve = resolve
       this.killChildProcesses()
     }).then(() => {
       this.killToken = undefined
     })
+
+    return this.killToken.promise
   }
 
   async run (...commands: Array<Command>): Promise<boolean> {

--- a/packages/core/src/State.js
+++ b/packages/core/src/State.js
@@ -5,7 +5,7 @@ import path from 'path'
 import File from './File'
 import Rule from './Rule'
 
-import type { Command, FileCache, RuleCache, Phase, Option } from './types'
+import type { Command, FileCache, RuleCache, Phase, Option, KillToken } from './types'
 
 export default class State extends EventEmitter {
   filePath: string
@@ -21,6 +21,7 @@ export default class State extends EventEmitter {
   processes: Set<number> = new Set()
   env: Object
   targets: Set<string> = new Set()
+  killToken: ?KillToken
 
   constructor (filePath: string, schema: Array<Option> = []) {
     super()

--- a/packages/core/src/StateConsumer.js
+++ b/packages/core/src/StateConsumer.js
@@ -55,7 +55,7 @@ export default class StateConsumer {
   }
 
   checkForKill (): void {
-    if (this.state.killToken) throw this.state.killToken.error
+    if (this.state.killToken && this.state.killToken.error) throw this.state.killToken.error
   }
 
   get ruleClasses (): Array<Class<Rule>> {

--- a/packages/core/src/StateConsumer.js
+++ b/packages/core/src/StateConsumer.js
@@ -9,7 +9,7 @@ import State from './State'
 import File from './File'
 import Rule from './Rule'
 
-import type { globOptions, Message } from './types'
+import type { globOptions, Message, KillToken } from './types'
 
 const VARIABLE_PATTERN = /\$\{?(\w+)\}?/g
 
@@ -44,6 +44,18 @@ export default class StateConsumer {
     for (const filePath of filePaths) {
       this.addResolvedTarget(filePath, reference)
     }
+  }
+
+  get killToken (): ?KillToken {
+    return this.state.killToken
+  }
+
+  set killToken (value: ?KillToken): void {
+    this.state.killToken = value
+  }
+
+  checkForKill (): void {
+    if (this.state.killToken) throw this.state.killToken.error
   }
 
   get ruleClasses (): Array<Class<Rule>> {

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -161,5 +161,6 @@ export type Option = {
 
 export type KillToken = {
   error: Error,
-  resolve: Function
+  resolve: Function,
+  promise: Promise<void>
 }

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -158,3 +158,8 @@ export type Option = {
   aliases?: Array<string>,
   commands: Array<string>
 }
+
+export type KillToken = {
+  error: Error,
+  resolve: Function
+}

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -160,7 +160,7 @@ export type Option = {
 }
 
 export type KillToken = {
-  error: Error,
-  resolve: Function,
-  promise: Promise<void>
+  error: ?Error,
+  resolve: ?Function,
+  promise: ?Promise<void>
 }


### PR DESCRIPTION
Improve the bailout response to rule failure and kill commands.

If all rules fail in the evaluation of a command phase then we currently just keep repeating the evaluation cycle until `phaseCycles` is reached. As a result we get a whole bunch of irritating messages in the log. This PR is an attempt to fix this.

- [x] Add bailout for complete rule failure
- [x] Add kill signal logic