### PR TITLE
Fix PatchSyncTeX Severity

### DIFF
--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -7,7 +7,7 @@ import State from './State'
 import File from './File'
 import StateConsumer from './StateConsumer'
 
-import type { Action, Command, Phase } from './types'
+import type { Action, Command, Phase, CommandOptions } from './types'
 
 export default class Rule extends StateConsumer {
   static fileTypes: Set<string> = new Set()
@@ -163,7 +163,8 @@ export default class Rule extends StateConsumer {
   async run (): Promise<boolean> {
     let success: boolean = true
     const options = this.constructProcessOptions()
-    const command = commandJoin(this.constructCommand())
+    const { args, severity } = this.constructCommand()
+    const command = commandJoin(args)
 
     this.emit('command', {
       type: 'command',
@@ -172,7 +173,7 @@ export default class Rule extends StateConsumer {
     })
     const { stdout, stderr, error } = await this.executeChildProcess(command, options)
     if (error) {
-      this.error(error.toString())
+      this.log({ severity, text: error.toString(), name: this.constructor.name })
       success = false
     }
     return await this.processOutput(stdout, stderr) && success
@@ -339,8 +340,8 @@ export default class Rule extends StateConsumer {
     return processOptions
   }
 
-  constructCommand (): Array<string> {
-    return []
+  constructCommand (): CommandOptions {
+    return { args: [], severity: 'error' }
   }
 
   actionTrace (action: Action) {

--- a/packages/core/src/Rules/Asymptote.js
+++ b/packages/core/src/Rules/Asymptote.js
@@ -20,12 +20,10 @@ export default class Asymptote extends Rule {
   }
 
   constructCommand () {
-    return [
-      'asy',
-      // '-offscreen',
-      '-vv',
-      this.resolvePath('$BASE', this.firstParameter)
-    ]
+    return {
+      args: ['asy', '-vv', this.resolvePath('$BASE', this.firstParameter)],
+      severity: 'error'
+    }
   }
 
   constructProcessOptions (): Object {

--- a/packages/core/src/Rules/BibTeX.js
+++ b/packages/core/src/Rules/BibTeX.js
@@ -48,7 +48,10 @@ export default class BibTeX extends Rule {
   }
 
   constructCommand () {
-    return ['bibtex', this.input ? this.input.filePath : '']
+    return {
+      args: ['bibtex', this.input ? this.input.filePath : ''],
+      severity: 'error'
+    }
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/Biber.js
+++ b/packages/core/src/Rules/Biber.js
@@ -31,7 +31,10 @@ export default class Biber extends Rule {
   }
 
   constructCommand () {
-    return ['biber', this.firstParameter.filePath]
+    return {
+      args: ['biber', this.firstParameter.filePath],
+      severity: 'error'
+    }
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/DviToPdf.js
+++ b/packages/core/src/Rules/DviToPdf.js
@@ -16,12 +16,15 @@ export default class DviToPdf extends Rule {
   }
 
   constructCommand () {
-    return [
-      'xdvipdfmx',
-      '-o',
-      this.resolvePath('$DIR/$NAME.pdf', this.firstParameter),
-      this.firstParameter.filePath
-    ]
+    return {
+      args: [
+        'xdvipdfmx',
+        '-o',
+        this.resolvePath('$DIR/$NAME.pdf', this.firstParameter),
+        this.firstParameter.filePath
+      ],
+      severity: 'error'
+    }
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/DviToPs.js
+++ b/packages/core/src/Rules/DviToPs.js
@@ -16,12 +16,15 @@ export default class DviToPs extends Rule {
   }
 
   constructCommand () {
-    return [
-      'dvips',
-      '-o',
-      this.resolvePath('$DIR/$NAME.ps', this.firstParameter),
-      this.firstParameter.filePath
-    ]
+    return {
+      args: [
+        'dvips',
+        '-o',
+        this.resolvePath('$DIR/$NAME.ps', this.firstParameter),
+        this.firstParameter.filePath
+      ],
+      severity: 'error'
+    }
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/DviToSvg.js
+++ b/packages/core/src/Rules/DviToSvg.js
@@ -16,12 +16,15 @@ export default class DviToSvg extends Rule {
   }
 
   constructCommand () {
-    return [
-      'dvisvgm',
-      '-o',
-      this.resolvePath('$DIR/$NAME.svg', this.firstParameter),
-      this.firstParameter.filePath
-    ]
+    return {
+      args: [
+        'dvisvgm',
+        '-o',
+        this.resolvePath('$DIR/$NAME.svg', this.firstParameter),
+        this.firstParameter.filePath
+      ],
+      severity: 'error'
+    }
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/GraphViz.js
+++ b/packages/core/src/Rules/GraphViz.js
@@ -14,12 +14,15 @@ export default class GraphViz extends Rule {
   constructCommand () {
     const { dir, name } = path.parse(this.firstParameter.filePath)
 
-    return [
-      'fdp',
-      `-T${this.options.outputFormat}`,
-      '-o',
-      path.format({ dir, name, ext: `.${this.options.outputFormat}` }),
-      this.firstParameter.filePath
-    ]
+    return {
+      args: [
+        'fdp',
+        `-T${this.options.outputFormat}`,
+        '-o',
+        path.format({ dir, name, ext: `.${this.options.outputFormat}` }),
+        this.firstParameter.filePath
+      ],
+      severity: 'error'
+    }
   }
 }

--- a/packages/core/src/Rules/Knitr.js
+++ b/packages/core/src/Rules/Knitr.js
@@ -22,6 +22,9 @@ export default class Knitr extends Rule {
     if (this.options.synctex) lines.push('opts_knit$set(concordance=TRUE)')
     lines.push(`knit('${filePath}')`)
 
-    return ['Rscript', '-e', lines.join(';')]
+    return {
+      args: ['Rscript', '-e', lines.join(';')],
+      severity: 'error'
+    }
   }
 }

--- a/packages/core/src/Rules/LaTeX.js
+++ b/packages/core/src/Rules/LaTeX.js
@@ -95,6 +95,9 @@ export default class LaTeX extends Rule {
 
     args.push(this.firstParameter.filePath)
 
-    return args
+    return {
+      args,
+      severity: 'error'
+    }
   }
 }

--- a/packages/core/src/Rules/LhsToTeX.js
+++ b/packages/core/src/Rules/LhsToTeX.js
@@ -13,6 +13,10 @@ export default class LhsToTeX extends Rule {
 
   constructCommand () {
     const outputPath = this.resolvePath('$DIR/$NAME.tex', this.firstParameter)
-    return ['lhs2TeX', '-o', outputPath, this.firstParameter.filePath]
+
+    return {
+      args: ['lhs2TeX', '-o', outputPath, this.firstParameter.filePath],
+      severity: 'error'
+    }
   }
 }

--- a/packages/core/src/Rules/MakeGlossaries.js
+++ b/packages/core/src/Rules/MakeGlossaries.js
@@ -24,6 +24,9 @@ export default class MakeGlossaries extends Rule {
     if (dir) args.push('-d', dir)
     args.push(name)
 
-    return args
+    return {
+      args,
+      severity: 'error'
+    }
   }
 }

--- a/packages/core/src/Rules/MakeIndex.js
+++ b/packages/core/src/Rules/MakeIndex.js
@@ -48,6 +48,9 @@ export default class MakeIndex extends Rule {
     if (this.stylePath) args.push('-s', this.stylePath)
     args.push(this.firstParameter.filePath)
 
-    return args
+    return {
+      args,
+      severity: 'error'
+    }
   }
 }

--- a/packages/core/src/Rules/MetaPost.js
+++ b/packages/core/src/Rules/MetaPost.js
@@ -7,10 +7,13 @@ export default class MetaPost extends Rule {
   static description: string = 'Runs MetaPost on produced MetaPost files.'
 
   constructCommand () {
-    return [
-      'mpost',
-      this.resolvePath('$BASE', this.firstParameter.filePath)
-    ]
+    return {
+      args: [
+        'mpost',
+        this.resolvePath('$BASE', this.firstParameter.filePath)
+      ],
+      severity: 'error'
+    }
   }
 
   constructProcessOptions (): Object {

--- a/packages/core/src/Rules/PatchSyncTeX.js
+++ b/packages/core/src/Rules/PatchSyncTeX.js
@@ -20,6 +20,9 @@ export default class PatchSyncTeX extends Rule {
       'library(patchSynctex)',
       `patchSynctex('${filePath}',syncfile='${synctexPath}')`]
 
-    return ['Rscript', '-e', lines.join(';')]
+    return {
+      args: ['Rscript', '-e', lines.join(';')],
+      severity: 'warning'
+    }
   }
 }

--- a/packages/core/src/Rules/PdfToPs.js
+++ b/packages/core/src/Rules/PdfToPs.js
@@ -16,11 +16,14 @@ export default class PdfToPs extends Rule {
   }
 
   constructCommand () {
-    return [
-      'pdf2ps',
-      this.firstParameter.filePath,
-      this.resolvePath('$DIR/$NAME.ps', this.firstParameter)
-    ]
+    return {
+      args: [
+        'pdf2ps',
+        this.firstParameter.filePath,
+        this.resolvePath('$DIR/$NAME.ps', this.firstParameter)
+      ],
+      severity: 'error'
+    }
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/PsToPdf.js
+++ b/packages/core/src/Rules/PsToPdf.js
@@ -16,11 +16,14 @@ export default class PsToPdf extends Rule {
   }
 
   constructCommand () {
-    return [
-      'ps2pdf',
-      this.firstParameter.filePath,
-      this.resolvePath('$DIR/$NAME.pdf', this.firstParameter)
-    ]
+    return {
+      args: [
+        'ps2pdf',
+        this.firstParameter.filePath,
+        this.resolvePath('$DIR/$NAME.pdf', this.firstParameter)
+      ],
+      severity: 'error'
+    }
   }
 
   async processOutput (stdout: string, stderr: string): Promise<boolean> {

--- a/packages/core/src/Rules/Sage.js
+++ b/packages/core/src/Rules/Sage.js
@@ -9,7 +9,10 @@ export default class Sage extends Rule {
   static description: string = 'Supports SageTeX by running Sage when needed.'
 
   constructCommand () {
-    return ['sage', path.basename(this.firstParameter.filePath)]
+    return {
+      args: ['sage', path.basename(this.firstParameter.filePath)],
+      severity: 'error'
+    }
   }
 
   constructProcessOptions (): Object {

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -164,3 +164,8 @@ export type KillToken = {
   resolve: ?Function,
   promise: ?Promise<void>
 }
+
+export type CommandOptions = {
+  args: Array<string>,
+  severity: Severity
+}


### PR DESCRIPTION
If SyncTeX is enabled then `PatchSyncTeX` is automatically called on the concordance file. If the user doesn't have the library installed the build will fail.

- [x] Add severity option to `constructCommand`.