### PR TITLE
Add action based failure flags

### DIFF
--- a/packages/core/src/File.js
+++ b/packages/core/src/File.js
@@ -79,7 +79,7 @@ export default class File {
     if (!file.virtual && !await File.canRead(realFilePath)) return
     // Check for an update to file in case it has changed since the cache was
     // finalized.
-    file.hasBeenUpdated = await file.updateTimeStamp() && await file.updateHash()
+    await file.update()
 
     return file
   }
@@ -325,7 +325,7 @@ export default class File {
     if (this.virtual) return false
     const oldTimeStamp = this.timeStamp
     this.timeStamp = await File.getModifiedTime(this.realFilePath)
-    return oldTimeStamp !== this.timeStamp
+    return oldTimeStamp < this.timeStamp
   }
 
   updateHash (): Promise<boolean> {

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -122,6 +122,7 @@ export default class Rule extends StateConsumer {
       const timeStamp: ?Date = this.timeStamp
       const ruleNeedsUpdate = !timeStamp || timeStamp < file.timeStamp
       for (const action of await this.getFileActions(file)) {
+        if (ruleNeedsUpdate) this.failures.clear()
         if (action === 'updateDependencies' || ruleNeedsUpdate) {
           this.addAction(file, action)
         }

--- a/packages/core/src/Rules/LoadAndValidateCache.js
+++ b/packages/core/src/Rules/LoadAndValidateCache.js
@@ -17,10 +17,6 @@ export default class LoadAndValidateCache extends Rule {
     this.cacheFilePath = this.resolvePath('$DIR/$NAME-cache.yaml')
   }
 
-  async preEvaluate () {
-    if (this.options.ignoreCache || !await File.canRead(this.cacheFilePath)) this.actions.delete('run')
-  }
-
   async run () {
     if (this.options.ignoreCache) {
       this.cleanCache()
@@ -32,6 +28,10 @@ export default class LoadAndValidateCache extends Rule {
         await this.validateCache()
       }
     }
+
+    // Get the main source file just in case it wasn't added by the cache load.
+    // This also lets the cache load test for a change in the main source file.
+    await this.getFile(this.filePath)
 
     this.calculateDistances()
 

--- a/packages/core/src/Rules/LoadAndValidateCache.js
+++ b/packages/core/src/Rules/LoadAndValidateCache.js
@@ -41,9 +41,7 @@ export default class LoadAndValidateCache extends Rule {
   cleanCache () {
     for (const jobName of this.options.jobNames) {
       for (const file of this.files) {
-        if (file.filePath !== this.filePath) {
-          this.state.deleteFile(file, jobName, false)
-        }
+        this.state.deleteFile(file, jobName, false)
       }
     }
   }

--- a/packages/core/src/State.js
+++ b/packages/core/src/State.js
@@ -56,7 +56,8 @@ export default class State extends EventEmitter {
     const state = new State(filePath, schema)
 
     // I've removed this line to allow for the cache to test for a file update
-    // in the main source file.
+    // in the main source file. This make the async not really needed anymore,
+    // but I'll leave for a bit just in case.
     // await state.getFile(filePath)
 
     return state

--- a/packages/core/src/State.js
+++ b/packages/core/src/State.js
@@ -55,7 +55,9 @@ export default class State extends EventEmitter {
   static async create (filePath: string, schema: Array<Option> = []) {
     const state = new State(filePath, schema)
 
-    await state.getFile(filePath)
+    // I've removed this line to allow for the cache to test for a file update
+    // in the main source file.
+    // await state.getFile(filePath)
 
     return state
   }

--- a/scripts/miktex-packages
+++ b/scripts/miktex-packages
@@ -12,7 +12,6 @@ filemod
 fp
 framed
 fvextra
-glossaries
 ifplatform
 index
 lineno


### PR DESCRIPTION
The `updateDependencies` action appears to be walking over the success flag of `run` action. This is an attempt to fix it.