### PR TITLE
Verify existence of targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   \[[#71][]].
 - `dviToPdfEngine` option to allow setting the program to use for DVI to PDF
   conversion \[[#72][]].
+- Verification of the existence of output targets \[[#76][]].
 
 ## [v0.8.0][] &mdash; 2017-08-15
 
@@ -139,6 +140,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [v0.2.0]: https://github.com/yitzchak/dicy/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/yitzchak/dicy/tree/v0.1.0
 
+[#76]: https://github.com/yitzchak/dicy/pull/76
 [#72]: https://github.com/yitzchak/dicy/pull/72
 [#71]: https://github.com/yitzchak/dicy/pull/71
 [#69]: https://github.com/yitzchak/dicy/pull/69

--- a/packages/core/src/Rules/CheckForMissingTargets.js
+++ b/packages/core/src/Rules/CheckForMissingTargets.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import Rule from '../Rule'
+
+import type { Phase } from '../types'
+
+export default class CheckForMissingTargets extends Rule {
+  static phases: Set<Phase> = new Set(['finalize'])
+  static alwaysEvaluate: boolean = true
+  static description: string = 'Check for missing targets which implies no applicable rules.'
+
+  async run (): Promise<boolean> {
+    const files = await this.getTargetFiles()
+    const jobName = this.options.jobName
+
+    if (!files.some(file => (!jobName && file.jobNames.size === 0) ||
+      (jobName && file.jobNames.has(jobName)))) {
+      const jobText = jobName ? ` with job name of \`${jobName}\`` : ''
+      this.error(`No rule capable of producing a target for main source file \`${this.options.filePath}\`${jobText}.`)
+    }
+
+    return true
+  }
+}

--- a/packages/core/src/Rules/CheckForMissingTargets.js
+++ b/packages/core/src/Rules/CheckForMissingTargets.js
@@ -13,9 +13,11 @@ export default class CheckForMissingTargets extends Rule {
     const files = await this.getTargetFiles()
     const jobName = this.options.jobName
 
+    // If targets found for this job then just return true.
     if ((!jobName && files.length !== 0) ||
       (jobName && files.some(file => file.jobNames.has(jobName)))) return true
 
+    // No targets found so log an error message and cause rule failure.
     const jobText = jobName ? ` with job name of \`${jobName}\`` : ''
     this.error(`No rule produced or was capable of producing a target for main source file \`${this.options.filePath}\`${jobText}.`)
 

--- a/packages/core/src/Rules/CheckForMissingTargets.js
+++ b/packages/core/src/Rules/CheckForMissingTargets.js
@@ -13,12 +13,12 @@ export default class CheckForMissingTargets extends Rule {
     const files = await this.getTargetFiles()
     const jobName = this.options.jobName
 
-    if (!files.some(file => (!jobName && file.jobNames.size === 0) ||
-      (jobName && file.jobNames.has(jobName)))) {
-      const jobText = jobName ? ` with job name of \`${jobName}\`` : ''
-      this.error(`No rule capable of producing a target for main source file \`${this.options.filePath}\`${jobText}.`)
-    }
+    if ((!jobName && files.length !== 0) ||
+      (jobName && files.some(file => file.jobNames.has(jobName)))) return true
 
-    return true
+    const jobText = jobName ? ` with job name of \`${jobName}\`` : ''
+    this.error(`No rule produced or was capable of producing a target for main source file \`${this.options.filePath}\`${jobText}.`)
+
+    return false
   }
 }

--- a/packages/core/src/State.js
+++ b/packages/core/src/State.js
@@ -140,6 +140,7 @@ export default class State extends EventEmitter {
   }
 
   async addCachedRule (cache: RuleCache): Promise<void> {
+    const options = this.getJobOptions(cache.jobName)
     const id = this.getRuleId(cache.name, cache.command, cache.phase, cache.jobName, ...cache.parameters)
     if (this.rules.has(id)) return
 
@@ -152,7 +153,7 @@ export default class State extends EventEmitter {
         parameters.push(parameter)
       }
       // $FlowIgnore
-      const rule = new RuleClass(this, cache.command, cache.phase, cache.jobName, ...parameters)
+      const rule = new RuleClass(this, cache.command, cache.phase, options, ...parameters)
       this.addNode(rule.id)
       await rule.initialize()
       this.rules.set(rule.id, rule)


### PR DESCRIPTION
Check to make sure that targets have been produced. Missing targets cause an error message to be produced. This makes sure that a call like the following will produce some kind of meaningful output.

```bash
$ dicy bl foo.bar
(ERROR)   [DiCy] No rule capable of producing a target for main source file `foo.bar`.
```