### PR TITLE
Simplify rule matching

### DIFF
--- a/packages/core/spec/Rules/Agda_spec.js
+++ b/packages/core/spec/Rules/Agda_spec.js
@@ -17,11 +17,11 @@ async function initialize ({
 }
 
 describe('Agda', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if literateAgdaEngine is \'agda\'', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await Agda.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await Agda.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -31,7 +31,7 @@ describe('Agda', () => {
         options: { literateAgdaEngine: 'lhs2TeX' }
       })
 
-      expect(await Agda.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await Agda.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/Agda_spec.js
+++ b/packages/core/spec/Rules/Agda_spec.js
@@ -21,7 +21,7 @@ describe('Agda', () => {
     it('returns true if literateAgdaEngine is \'agda\'', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await Agda.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await Agda.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -31,7 +31,7 @@ describe('Agda', () => {
         options: { literateAgdaEngine: 'lhs2TeX' }
       })
 
-      expect(await Agda.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await Agda.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/CheckForMissingBuildRule_spec.js
+++ b/packages/core/spec/Rules/CheckForMissingBuildRule_spec.js
@@ -26,7 +26,7 @@ describe('CheckForMissingBuildRule', () => {
         }]
       })
 
-      expect(await CheckForMissingBuildRule.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await CheckForMissingBuildRule.isApplicable(dicy.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -38,7 +38,7 @@ describe('CheckForMissingBuildRule', () => {
         }]
       })
 
-      expect(await CheckForMissingBuildRule.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CheckForMissingBuildRule.isApplicable(dicy.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -48,7 +48,7 @@ describe('CheckForMissingBuildRule', () => {
     it('run succeeds and does not log any error messages when build rules are present.', async (done) => {
       const { dicy, rule, options } = await initialize()
       const file = await dicy.getFile('LaTeX_article.tex')
-      const otherRule = new Rule(rule.state, 'build', 'execute', options, file)
+      const otherRule = new Rule(rule.state, 'build', 'execute', options, [file])
 
       dicy.addRule(otherRule)
 
@@ -76,7 +76,7 @@ describe('CheckForMissingBuildRule', () => {
         options: { jobName: 'foo' }
       })
       const file = await dicy.getFile('LaTeX_article.tex')
-      const otherRule = new Rule(rule.state, 'build', 'execute', options, file)
+      const otherRule = new Rule(rule.state, 'build', 'execute', options, [file])
 
       dicy.addRule(otherRule)
 

--- a/packages/core/spec/Rules/CheckForMissingBuildRule_spec.js
+++ b/packages/core/spec/Rules/CheckForMissingBuildRule_spec.js
@@ -18,7 +18,7 @@ async function initialize ({
 }
 
 describe('CheckForMissingBuildRule', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if the parameter is the main source file.', async (done) => {
       const { dicy, rule, options } = await initialize({
         parameters: [{
@@ -26,7 +26,7 @@ describe('CheckForMissingBuildRule', () => {
         }]
       })
 
-      expect(await CheckForMissingBuildRule.appliesToParameters(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await CheckForMissingBuildRule.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -38,7 +38,7 @@ describe('CheckForMissingBuildRule', () => {
         }]
       })
 
-      expect(await CheckForMissingBuildRule.appliesToParameters(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CheckForMissingBuildRule.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/CopyTargetsToRoot_spec.js
+++ b/packages/core/spec/Rules/CopyTargetsToRoot_spec.js
@@ -27,7 +27,7 @@ describe('CopyTargetsToRoot', () => {
       })
 
       rule.addTarget(rule.firstParameter.filePath)
-      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -40,7 +40,7 @@ describe('CopyTargetsToRoot', () => {
       })
 
       rule.addTarget(filePath)
-      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -53,7 +53,7 @@ describe('CopyTargetsToRoot', () => {
       })
 
       rule.addTarget(filePath)
-      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -63,7 +63,7 @@ describe('CopyTargetsToRoot', () => {
         options: { copyTargetsToRoot: true }
       })
 
-      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -72,7 +72,7 @@ describe('CopyTargetsToRoot', () => {
       const { rule, options } = await initialize()
 
       rule.addTarget(rule.firstParameter.filePath)
-      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/CopyTargetsToRoot_spec.js
+++ b/packages/core/spec/Rules/CopyTargetsToRoot_spec.js
@@ -20,14 +20,14 @@ async function initialize ({
 }
 
 describe('CopyTargetsToRoot', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if parameter is a target', async (done) => {
       const { rule, options } = await initialize({
         options: { copyTargetsToRoot: true }
       })
 
       rule.addTarget(rule.firstParameter.filePath)
-      expect(await CopyTargetsToRoot.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -40,7 +40,7 @@ describe('CopyTargetsToRoot', () => {
       })
 
       rule.addTarget(filePath)
-      expect(await CopyTargetsToRoot.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -53,7 +53,7 @@ describe('CopyTargetsToRoot', () => {
       })
 
       rule.addTarget(filePath)
-      expect(await CopyTargetsToRoot.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -63,7 +63,7 @@ describe('CopyTargetsToRoot', () => {
         options: { copyTargetsToRoot: true }
       })
 
-      expect(await CopyTargetsToRoot.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -72,7 +72,7 @@ describe('CopyTargetsToRoot', () => {
       const { rule, options } = await initialize()
 
       rule.addTarget(rule.firstParameter.filePath)
-      expect(await CopyTargetsToRoot.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await CopyTargetsToRoot.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/CreateOutputTree_spec.js
+++ b/packages/core/spec/Rules/CreateOutputTree_spec.js
@@ -16,7 +16,7 @@ describe('CreateOutputTree', () => {
     it('returns false if outputDirectory is not set.', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await CreateOutputTree.appliesToPhase(rule.state, 'build', 'initialize', options)).toBe(false)
+      expect(await CreateOutputTree.isApplicable(rule.state, 'build', 'initialize', options)).toBe(false)
 
       done()
     })
@@ -26,7 +26,7 @@ describe('CreateOutputTree', () => {
         options: { outputDirectory: '.' }
       })
 
-      expect(await CreateOutputTree.appliesToPhase(rule.state, 'build', 'initialize', options)).toBe(false)
+      expect(await CreateOutputTree.isApplicable(rule.state, 'build', 'initialize', options)).toBe(false)
 
       done()
     })
@@ -36,7 +36,7 @@ describe('CreateOutputTree', () => {
         options: { outputDirectory: 'foo' }
       })
 
-      expect(await CreateOutputTree.appliesToPhase(rule.state, 'build', 'initialize', options)).toBe(true)
+      expect(await CreateOutputTree.isApplicable(rule.state, 'build', 'initialize', options)).toBe(true)
 
       done()
     })

--- a/packages/core/spec/Rules/DviToPdf_spec.js
+++ b/packages/core/spec/Rules/DviToPdf_spec.js
@@ -23,7 +23,7 @@ describe('DviToPdf', () => {
         options: { outputFormat: 'pdf' }
       })
 
-      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('DviToPdf', () => {
         options: { outputFormat: 'ps' }
       })
 
-      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -43,7 +43,7 @@ describe('DviToPdf', () => {
         options: { outputFormat: 'pdf', intermediatePostScript: true }
       })
 
-      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/DviToPdf_spec.js
+++ b/packages/core/spec/Rules/DviToPdf_spec.js
@@ -17,13 +17,13 @@ async function initialize ({
 }
 
 describe('DviToPdf', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if outputFormat is \'pdf\'', async (done) => {
       const { rule, options } = await initialize({
         options: { outputFormat: 'pdf' }
       })
 
-      expect(await DviToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('DviToPdf', () => {
         options: { outputFormat: 'ps' }
       })
 
-      expect(await DviToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -43,7 +43,7 @@ describe('DviToPdf', () => {
         options: { outputFormat: 'pdf', intermediatePostScript: true }
       })
 
-      expect(await DviToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/DviToPs_spec.js
+++ b/packages/core/spec/Rules/DviToPs_spec.js
@@ -17,13 +17,13 @@ async function initialize ({
 }
 
 describe('DviToPs', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if outputFormat is \'ps\'', async (done) => {
       const { rule, options } = await initialize({
         options: { outputFormat: 'ps' }
       })
 
-      expect(await DviToPs.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('DviToPs', () => {
         options: { outputFormat: 'pdf', intermediatePostScript: true }
       })
 
-      expect(await DviToPs.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -43,7 +43,7 @@ describe('DviToPs', () => {
         options: { outputFormat: 'dvi' }
       })
 
-      expect(await DviToPs.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/DviToPs_spec.js
+++ b/packages/core/spec/Rules/DviToPs_spec.js
@@ -23,7 +23,7 @@ describe('DviToPs', () => {
         options: { outputFormat: 'ps' }
       })
 
-      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('DviToPs', () => {
         options: { outputFormat: 'pdf', intermediatePostScript: true }
       })
 
-      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -43,7 +43,7 @@ describe('DviToPs', () => {
         options: { outputFormat: 'dvi' }
       })
 
-      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToPs.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/DviToSvg_spec.js
+++ b/packages/core/spec/Rules/DviToSvg_spec.js
@@ -23,7 +23,7 @@ describe('DviToSvg', () => {
         options: { outputFormat: 'svg' }
       })
 
-      expect(await DviToSvg.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToSvg.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('DviToSvg', () => {
         options: { outputFormat: 'dvi' }
       })
 
-      expect(await DviToSvg.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToSvg.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/DviToSvg_spec.js
+++ b/packages/core/spec/Rules/DviToSvg_spec.js
@@ -17,13 +17,13 @@ async function initialize ({
 }
 
 describe('DviToSvg', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if outputFormat is \'svg\'', async (done) => {
       const { rule, options } = await initialize({
         options: { outputFormat: 'svg' }
       })
 
-      expect(await DviToSvg.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await DviToSvg.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('DviToSvg', () => {
         options: { outputFormat: 'dvi' }
       })
 
-      expect(await DviToSvg.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await DviToSvg.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/EpsToPdf_spec.js
+++ b/packages/core/spec/Rules/EpsToPdf_spec.js
@@ -25,7 +25,7 @@ describe('EpsToPdf', () => {
         filePath: 'file-types/EncapsulatedPostScript.eps'
       })
 
-      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('EpsToPdf', () => {
     it('returns false if EPS file is not the main source file.', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -57,7 +57,7 @@ describe('EpsToPdf', () => {
         }]
       })
 
-      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -81,7 +81,7 @@ describe('EpsToPdf', () => {
         }]
       })
 
-      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/EpsToPdf_spec.js
+++ b/packages/core/spec/Rules/EpsToPdf_spec.js
@@ -19,13 +19,13 @@ async function initialize ({
 }
 
 describe('EpsToPdf', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if EPS file is the main source file.', async (done) => {
       const { rule, options } = await initialize({
         filePath: 'file-types/EncapsulatedPostScript.eps'
       })
 
-      expect(await EpsToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('EpsToPdf', () => {
     it('returns false if EPS file is not the main source file.', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await EpsToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -57,7 +57,7 @@ describe('EpsToPdf', () => {
         }]
       })
 
-      expect(await EpsToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -81,7 +81,7 @@ describe('EpsToPdf', () => {
         }]
       })
 
-      expect(await EpsToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await EpsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/LaTeX_spec.js
+++ b/packages/core/spec/Rules/LaTeX_spec.js
@@ -22,7 +22,7 @@ describe('LaTeX', () => {
         }]
       })
 
-      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -34,7 +34,7 @@ describe('LaTeX', () => {
         }]
       })
 
-      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -47,7 +47,7 @@ describe('LaTeX', () => {
       })
       const parameters = await rule.getFiles(['LaTeX_standalone.tex'])
 
-      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, parameters)).toBe(false)
 
       done()
     })
@@ -60,7 +60,7 @@ describe('LaTeX', () => {
         options: { literateAgdaEngine: 'none' }
       })
 
-      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -73,7 +73,7 @@ describe('LaTeX', () => {
         options: { literateAgdaEngine: 'agda' }
       })
 
-      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -86,7 +86,7 @@ describe('LaTeX', () => {
         options: { literateHaskellEngine: 'none' }
       })
 
-      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -99,7 +99,7 @@ describe('LaTeX', () => {
         options: { literateHaskellEngine: 'lhs2TeX' }
       })
 
-      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/LaTeX_spec.js
+++ b/packages/core/spec/Rules/LaTeX_spec.js
@@ -14,7 +14,7 @@ async function initialize ({
 }
 
 describe('LaTeX', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if file type is \'LaTeX\'', async (done) => {
       const { rule, options } = await initialize({
         parameters: [{
@@ -22,7 +22,7 @@ describe('LaTeX', () => {
         }]
       })
 
-      expect(await LaTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -34,7 +34,7 @@ describe('LaTeX', () => {
         }]
       })
 
-      expect(await LaTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -47,7 +47,7 @@ describe('LaTeX', () => {
       })
       const parameters = await rule.getFiles(['LaTeX_standalone.tex'])
 
-      expect(await LaTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...parameters)).toBe(false)
 
       done()
     })
@@ -60,7 +60,7 @@ describe('LaTeX', () => {
         options: { literateAgdaEngine: 'none' }
       })
 
-      expect(await LaTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -73,7 +73,7 @@ describe('LaTeX', () => {
         options: { literateAgdaEngine: 'agda' }
       })
 
-      expect(await LaTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -86,7 +86,7 @@ describe('LaTeX', () => {
         options: { literateHaskellEngine: 'none' }
       })
 
-      expect(await LaTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -99,7 +99,7 @@ describe('LaTeX', () => {
         options: { literateHaskellEngine: 'lhs2TeX' }
       })
 
-      expect(await LaTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LaTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/LhsToTeX_spec.js
+++ b/packages/core/spec/Rules/LhsToTeX_spec.js
@@ -17,11 +17,11 @@ async function initialize ({
 }
 
 describe('LhsToTeX', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if file type is \'LiterateHaskell\'', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await LhsToTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -32,7 +32,7 @@ describe('LhsToTeX', () => {
         options: { literateAgdaEngine: 'lhs2TeX' }
       })
 
-      expect(await LhsToTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -42,7 +42,7 @@ describe('LhsToTeX', () => {
         parameters: [{ filePath: 'LiterateAgda.lagda' }]
       })
 
-      expect(await LhsToTeX.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/LhsToTeX_spec.js
+++ b/packages/core/spec/Rules/LhsToTeX_spec.js
@@ -21,7 +21,7 @@ describe('LhsToTeX', () => {
     it('returns true if file type is \'LiterateHaskell\'', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -32,7 +32,7 @@ describe('LhsToTeX', () => {
         options: { literateAgdaEngine: 'lhs2TeX' }
       })
 
-      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -42,7 +42,7 @@ describe('LhsToTeX', () => {
         parameters: [{ filePath: 'LiterateAgda.lagda' }]
       })
 
-      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await LhsToTeX.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/MakeIndex_spec.js
+++ b/packages/core/spec/Rules/MakeIndex_spec.js
@@ -35,7 +35,7 @@ describe('MakeIndex', () => {
         }]
       })
 
-      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -58,7 +58,7 @@ describe('MakeIndex', () => {
         }]
       })
 
-      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -82,7 +82,7 @@ describe('MakeIndex', () => {
         }]
       })
 
-      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/MakeIndex_spec.js
+++ b/packages/core/spec/Rules/MakeIndex_spec.js
@@ -19,7 +19,7 @@ async function initialize ({
 }
 
 describe('MakeIndex', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if there are no splitindex notices in the log.', async (done) => {
       const { dicy, rule, options } = await initialize({
         parameters: [{
@@ -35,7 +35,7 @@ describe('MakeIndex', () => {
         }]
       })
 
-      expect(await MakeIndex.appliesToParameters(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -58,7 +58,7 @@ describe('MakeIndex', () => {
         }]
       })
 
-      expect(await MakeIndex.appliesToParameters(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -82,7 +82,7 @@ describe('MakeIndex', () => {
         }]
       })
 
-      expect(await MakeIndex.appliesToParameters(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await MakeIndex.isApplicable(dicy.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/PdfToPs_spec.js
+++ b/packages/core/spec/Rules/PdfToPs_spec.js
@@ -17,13 +17,13 @@ async function initialize ({
 }
 
 describe('PdfToPs', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if outputFormat is \'ps\'', async (done) => {
       const { rule, options } = await initialize({
         options: { outputFormat: 'ps' }
       })
 
-      expect(await PdfToPs.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await PdfToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('PdfToPs', () => {
         options: { outputFormat: 'pdf' }
       })
 
-      expect(await PdfToPs.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await PdfToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/PdfToPs_spec.js
+++ b/packages/core/spec/Rules/PdfToPs_spec.js
@@ -23,7 +23,7 @@ describe('PdfToPs', () => {
         options: { outputFormat: 'ps' }
       })
 
-      expect(await PdfToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await PdfToPs.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('PdfToPs', () => {
         options: { outputFormat: 'pdf' }
       })
 
-      expect(await PdfToPs.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await PdfToPs.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/PsToPdf_spec.js
+++ b/packages/core/spec/Rules/PsToPdf_spec.js
@@ -23,7 +23,7 @@ describe('PsToPdf', () => {
         options: { outputFormat: 'pdf' }
       })
 
-      expect(await PsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await PsToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('PsToPdf', () => {
         options: { outputFormat: 'ps' }
       })
 
-      expect(await PsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await PsToPdf.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/PsToPdf_spec.js
+++ b/packages/core/spec/Rules/PsToPdf_spec.js
@@ -17,13 +17,13 @@ async function initialize ({
 }
 
 describe('PsToPdf', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns true if outputFormat is \'pdf\'', async (done) => {
       const { rule, options } = await initialize({
         options: { outputFormat: 'pdf' }
       })
 
-      expect(await PsToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await PsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -33,7 +33,7 @@ describe('PsToPdf', () => {
         options: { outputFormat: 'ps' }
       })
 
-      expect(await PsToPdf.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await PsToPdf.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })

--- a/packages/core/spec/Rules/SplitIndex_spec.js
+++ b/packages/core/spec/Rules/SplitIndex_spec.js
@@ -23,7 +23,7 @@ describe('SplitIndex', () => {
     it('returns false if there are no splitindex notices in the log.', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(false)
 
       done()
     })
@@ -46,7 +46,7 @@ describe('SplitIndex', () => {
         }]
       })
 
-      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })
@@ -70,7 +70,7 @@ describe('SplitIndex', () => {
         }]
       })
 
-      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, rule.parameters)).toBe(true)
 
       done()
     })

--- a/packages/core/spec/Rules/SplitIndex_spec.js
+++ b/packages/core/spec/Rules/SplitIndex_spec.js
@@ -19,11 +19,11 @@ async function initialize ({
 }
 
 describe('SplitIndex', () => {
-  describe('appliesToParameters', () => {
+  describe('isApplicable', () => {
     it('returns false if there are no splitindex notices in the log.', async (done) => {
       const { rule, options } = await initialize()
 
-      expect(await SplitIndex.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
+      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(false)
 
       done()
     })
@@ -46,7 +46,7 @@ describe('SplitIndex', () => {
         }]
       })
 
-      expect(await SplitIndex.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })
@@ -70,7 +70,7 @@ describe('SplitIndex', () => {
         }]
       })
 
-      expect(await SplitIndex.appliesToParameters(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
+      expect(await SplitIndex.isApplicable(rule.state, 'build', 'execute', options, ...rule.parameters)).toBe(true)
 
       done()
     })

--- a/packages/core/spec/State_spec.js
+++ b/packages/core/spec/State_spec.js
@@ -11,7 +11,7 @@ describe('State', () => {
   })
 
   it('verifies that getRuleId returns expected id', () => {
-    const result = state.getRuleId('quux', 'build', 'execute', 'bar', 'foo.tex')
+    const result = state.getRuleId('quux', 'build', 'execute', 'bar', ['foo.tex'])
     const expectedResult = 'quux(build;execute;bar;foo.tex)'
     expect(result).toEqual(expectedResult)
   })

--- a/packages/core/spec/helpers.js
+++ b/packages/core/spec/helpers.js
@@ -134,7 +134,7 @@ export async function initializeRule ({ RuleClass, command, phase, jobName, file
     phase = RuleClass.phases.values().next().value || 'execute'
   }
   const jobOptions = dicy.state.getJobOptions(jobName)
-  const rule = new RuleClass(dicy.state, command, phase, jobOptions, ...files)
+  const rule = new RuleClass(dicy.state, command, phase, jobOptions, files)
 
   spyOn(rule, 'log')
   await rule.initialize()

--- a/packages/core/src/DiCy.js
+++ b/packages/core/src/DiCy.js
@@ -16,7 +16,7 @@ const VALID_COMMAND_PATTERN = /^(build|clean|graph|load|log|save|scrub)$/
 export default class DiCy extends StateConsumer {
   static async create (filePath: string, options: Object = {}) {
     const schema = await DiCy.getOptionDefinitions()
-    const state = await State.create(filePath, schema)
+    const state = new State(filePath, schema)
     const builder = new DiCy(state, state.getJobOptions())
 
     await builder.initialize()

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -61,11 +61,12 @@ export default class Rule extends StateConsumer {
           let indicies = candidates.map(files => files.length - 1)
 
           while (indicies.every(index => index > -1)) {
-            const parameters = candidates.map((files, index) => files[indicies[index]])
-            const ruleId = state.getRuleId(this.name, command, phase, options.jobName, ...parameters)
+            const parameters: Array<File> = candidates.map((files, index) => files[indicies[index]])
+            // $FlowIgnore
+            const ruleId: string = state.getRuleId(this.name, command, phase, options.jobName, parameters.map(file => file.filePath))
 
-            if (!state.rules.has(ruleId) && await this.isApplicable(state, command, phase, options, ...parameters)) {
-              const rule = new this(state, command, phase, options, ...parameters)
+            if (!state.rules.has(ruleId) && await this.isApplicable(state, command, phase, options, parameters)) {
+              const rule = new this(state, command, phase, options, parameters)
               await rule.initialize()
               if (rule.alwaysEvaluate) rule.addActions(file)
               rules.push(rule)
@@ -86,17 +87,17 @@ export default class Rule extends StateConsumer {
     return rules
   }
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     return true
   }
 
-  constructor (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>) {
+  constructor (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []) {
     super(state, options)
 
     this.parameters = parameters
     this.command = command
     this.phase = phase
-    this.id = state.getRuleId(this.constructor.name, command, phase, options.jobName, ...parameters)
+    this.id = state.getRuleId(this.constructor.name, command, phase, options.jobName, parameters.map(file => file.filePath))
 
     this.parameters.forEach((file, index) => {
       const { dir, base, name, ext } = path.parse(file.filePath)

--- a/packages/core/src/Rule.js
+++ b/packages/core/src/Rule.js
@@ -33,7 +33,10 @@ export default class Rule extends StateConsumer {
   failures: Set<Action> = new Set()
 
   static async analyzePhase (state: State, command: Command, phase: Phase, options: OptionsInterface): Promise<?Rule> {
-    if (await this.appliesToPhase(state, command, phase, options)) {
+    const appliesToPhase: boolean = this.commands.has(command) && this.phases.has(phase) &&
+          this.parameterTypes.length === 0
+
+    if (appliesToPhase && await this.isApplicable(state, command, phase, options)) {
       const rule = new this(state, command, phase, options)
       await rule.initialize()
       if (rule.alwaysEvaluate) rule.addActions()
@@ -41,17 +44,13 @@ export default class Rule extends StateConsumer {
     }
   }
 
-  static async appliesToPhase (state: State, command: Command, phase: Phase, options: OptionsInterface): Promise<boolean> {
-    return this.commands.has(command) &&
-      this.phases.has(phase) &&
-      this.parameterTypes.length === 0
-  }
-
   static async analyzeFile (state: State, command: Command, phase: Phase, options: OptionsInterface, file: File): Promise<Array<Rule>> {
-    const rules = []
+    const rules: Array<Rule> = []
+    const appliesToFile: boolean = this.commands.has(command) && this.phases.has(phase) &&
+          this.parameterTypes.some(types => file && file.inTypeSet(types))
 
-    if (await this.appliesToFile(state, command, phase, options, file)) {
-      const files = Array.from(state.files.values()).filter(file => !options.jobName || file.jobNames.has(options.jobName))
+    if (appliesToFile) {
+      const files: Array<File> = Array.from(state.files.values()).filter(file => !options.jobName || file.jobNames.has(options.jobName))
 
       for (let i = 0; i < this.parameterTypes.length; i++) {
         if (file.inTypeSet(this.parameterTypes[i])) {
@@ -65,7 +64,7 @@ export default class Rule extends StateConsumer {
             const parameters = candidates.map((files, index) => files[indicies[index]])
             const ruleId = state.getRuleId(this.name, command, phase, options.jobName, ...parameters)
 
-            if (!state.rules.has(ruleId) && await this.appliesToParameters(state, command, phase, options, ...parameters)) {
+            if (!state.rules.has(ruleId) && await this.isApplicable(state, command, phase, options, ...parameters)) {
               const rule = new this(state, command, phase, options, ...parameters)
               await rule.initialize()
               if (rule.alwaysEvaluate) rule.addActions(file)
@@ -87,14 +86,8 @@ export default class Rule extends StateConsumer {
     return rules
   }
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     return true
-  }
-
-  static async appliesToFile (state: State, command: Command, phase: Phase, options: OptionsInterface, file: File): Promise<boolean> {
-    return this.commands.has(command) &&
-      this.phases.has(phase) &&
-      this.parameterTypes.some(types => file.inTypeSet(types))
   }
 
   constructor (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>) {

--- a/packages/core/src/Rules/Agda.js
+++ b/packages/core/src/Rules/Agda.js
@@ -10,7 +10,7 @@ export default class Agda extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['LiterateAgda'])]
   static description: string = 'Runs agda on lagda files.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     // Only apply if the literate Agda engince is set to agda
     return options.literateAgdaEngine === 'agda'
   }

--- a/packages/core/src/Rules/Agda.js
+++ b/packages/core/src/Rules/Agda.js
@@ -10,7 +10,7 @@ export default class Agda extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['LiterateAgda'])]
   static description: string = 'Runs agda on lagda files.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     // Only apply if the literate Agda engince is set to agda
     return options.literateAgdaEngine === 'agda'
   }

--- a/packages/core/src/Rules/BibTeX.js
+++ b/packages/core/src/Rules/BibTeX.js
@@ -18,7 +18,7 @@ export default class BibTeX extends Rule {
   ]
   static description: string = 'Runs BibTeX to process bibliography files (bib) when need is detected.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     return state.isGrandparentOf(parameters[0], parameters[1]) &&
       !!parameters[1].value && !!parameters[1].value.bibdata
   }

--- a/packages/core/src/Rules/BibTeX.js
+++ b/packages/core/src/Rules/BibTeX.js
@@ -18,7 +18,7 @@ export default class BibTeX extends Rule {
   ]
   static description: string = 'Runs BibTeX to process bibliography files (bib) when need is detected.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     return state.isGrandparentOf(parameters[0], parameters[1]) &&
       !!parameters[1].value && !!parameters[1].value.bibdata
   }

--- a/packages/core/src/Rules/CheckForMissingBuildRule.js
+++ b/packages/core/src/Rules/CheckForMissingBuildRule.js
@@ -12,7 +12,7 @@ export default class CheckForMissingBuildRule extends Rule {
   static alwaysEvaluate: boolean = true
   static description: string = 'Check for no applicable build rule.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     // Only apply if parameter is main source file for job.
     return parameters.some(file => file.filePath === options.filePath)
   }

--- a/packages/core/src/Rules/CheckForMissingBuildRule.js
+++ b/packages/core/src/Rules/CheckForMissingBuildRule.js
@@ -12,7 +12,7 @@ export default class CheckForMissingBuildRule extends Rule {
   static alwaysEvaluate: boolean = true
   static description: string = 'Check for no applicable build rule.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     // Only apply if parameter is main source file for job.
     return parameters.some(file => file.filePath === options.filePath)
   }

--- a/packages/core/src/Rules/CopyTargetsToRoot.js
+++ b/packages/core/src/Rules/CopyTargetsToRoot.js
@@ -13,7 +13,7 @@ export default class CopyTargetsToRoot extends Rule {
   static description: string = 'Copy targets to root directory.'
   static alwaysEvaluate: boolean = true
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     return !!options.copyTargetsToRoot &&
       parameters.every(file => !file.virtual && state.targets.has(file.filePath) && path.dirname(file.filePath) !== '.')
   }

--- a/packages/core/src/Rules/CopyTargetsToRoot.js
+++ b/packages/core/src/Rules/CopyTargetsToRoot.js
@@ -13,7 +13,7 @@ export default class CopyTargetsToRoot extends Rule {
   static description: string = 'Copy targets to root directory.'
   static alwaysEvaluate: boolean = true
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     return !!options.copyTargetsToRoot &&
       parameters.every(file => !file.virtual && state.targets.has(file.filePath) && path.dirname(file.filePath) !== '.')
   }

--- a/packages/core/src/Rules/CreateOutputTree.js
+++ b/packages/core/src/Rules/CreateOutputTree.js
@@ -13,7 +13,7 @@ export default class CreateOutputTree extends Rule {
   static alwaysEvaluate: boolean = true
   static description: string = 'Create directory tree for aux files when `outputDirectory` is set.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     return !!options.outputDirectory && options.outputDirectory !== '.'
   }
 

--- a/packages/core/src/Rules/CreateOutputTree.js
+++ b/packages/core/src/Rules/CreateOutputTree.js
@@ -13,11 +13,8 @@ export default class CreateOutputTree extends Rule {
   static alwaysEvaluate: boolean = true
   static description: string = 'Create directory tree for aux files when `outputDirectory` is set.'
 
-  static async appliesToPhase (state: State, command: Command, phase: Phase, options: OptionsInterface): Promise<boolean> {
-    return this.commands.has(command) &&
-      this.phases.has(phase) &&
-      this.parameterTypes.length === 0 &&
-      !!options.outputDirectory && options.outputDirectory !== '.'
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+    return !!options.outputDirectory && options.outputDirectory !== '.'
   }
 
   async run () {

--- a/packages/core/src/Rules/DviToPdf.js
+++ b/packages/core/src/Rules/DviToPdf.js
@@ -10,7 +10,7 @@ export default class DviToPdf extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['DeviceIndependentFile'])]
   static description: string = 'Converts DVI to PDF using (x)dvipdfm(x).'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     // Only apply if output format is pdf and intermediate PostScript generation
     // is off.
     return options.outputFormat === 'pdf' && !options.intermediatePostScript

--- a/packages/core/src/Rules/DviToPdf.js
+++ b/packages/core/src/Rules/DviToPdf.js
@@ -10,7 +10,7 @@ export default class DviToPdf extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['DeviceIndependentFile'])]
   static description: string = 'Converts DVI to PDF using (x)dvipdfm(x).'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     // Only apply if output format is pdf and intermediate PostScript generation
     // is off.
     return options.outputFormat === 'pdf' && !options.intermediatePostScript

--- a/packages/core/src/Rules/DviToPs.js
+++ b/packages/core/src/Rules/DviToPs.js
@@ -10,7 +10,7 @@ export default class DviToPs extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['DeviceIndependentFile'])]
   static description: string = 'Converts DVI to PS using dvips.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     // Only apply if output format is ps or intermediate PostScript generation
     // is on.
     return options.outputFormat === 'ps' ||

--- a/packages/core/src/Rules/DviToPs.js
+++ b/packages/core/src/Rules/DviToPs.js
@@ -10,7 +10,7 @@ export default class DviToPs extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['DeviceIndependentFile'])]
   static description: string = 'Converts DVI to PS using dvips.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     // Only apply if output format is ps or intermediate PostScript generation
     // is on.
     return options.outputFormat === 'ps' ||

--- a/packages/core/src/Rules/DviToSvg.js
+++ b/packages/core/src/Rules/DviToSvg.js
@@ -10,7 +10,7 @@ export default class DviToSvg extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['DeviceIndependentFile'])]
   static description: string = 'Converts DVI to SVG using dvisvgm.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     // Only apply if output format is svg
     return options.outputFormat === 'svg'
   }

--- a/packages/core/src/Rules/DviToSvg.js
+++ b/packages/core/src/Rules/DviToSvg.js
@@ -10,7 +10,7 @@ export default class DviToSvg extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['DeviceIndependentFile'])]
   static description: string = 'Converts DVI to SVG using dvisvgm.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     // Only apply if output format is svg
     return options.outputFormat === 'svg'
   }

--- a/packages/core/src/Rules/EpsToPdf.js
+++ b/packages/core/src/Rules/EpsToPdf.js
@@ -16,7 +16,7 @@ export default class EpsToPdf extends Rule {
   ]
   static description: string = 'Converts EPS to PDF using epstopdf.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     switch (parameters[1].type) {
       case 'Nil':
         // If there is not a LaTeX log present then only apply epstopdf when the

--- a/packages/core/src/Rules/EpsToPdf.js
+++ b/packages/core/src/Rules/EpsToPdf.js
@@ -16,7 +16,7 @@ export default class EpsToPdf extends Rule {
   ]
   static description: string = 'Converts EPS to PDF using epstopdf.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     switch (parameters[1].type) {
       case 'Nil':
         // If there is not a LaTeX log present then only apply epstopdf when the

--- a/packages/core/src/Rules/LaTeX.js
+++ b/packages/core/src/Rules/LaTeX.js
@@ -20,7 +20,7 @@ export default class LaTeX extends Rule {
   ])]
   static description: string = 'Runs the required latex variant.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     return parameters.some(file =>
       ((file.type === 'LaTeX' && (file.filePath === state.filePath || !SUB_FILE_SUB_TYPES.includes(file.subType))) ||
       (file.type === 'LiterateHaskell' && options.literateHaskellEngine === 'none') ||

--- a/packages/core/src/Rules/LaTeX.js
+++ b/packages/core/src/Rules/LaTeX.js
@@ -20,7 +20,7 @@ export default class LaTeX extends Rule {
   ])]
   static description: string = 'Runs the required latex variant.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     return parameters.some(file =>
       ((file.type === 'LaTeX' && (file.filePath === state.filePath || !SUB_FILE_SUB_TYPES.includes(file.subType))) ||
       (file.type === 'LiterateHaskell' && options.literateHaskellEngine === 'none') ||

--- a/packages/core/src/Rules/LhsToTeX.js
+++ b/packages/core/src/Rules/LhsToTeX.js
@@ -13,7 +13,7 @@ export default class LhsToTeX extends Rule {
   ])]
   static description: string = 'Runs lhs2TeX on lhs or lagda files.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     return parameters.some(file => ((file.type === 'LiterateHaskell' && options.literateHaskellEngine === 'lhs2TeX') ||
       (file.type === 'LiterateAgda' && options.literateAgdaEngine === 'lhs2TeX')))
   }

--- a/packages/core/src/Rules/LhsToTeX.js
+++ b/packages/core/src/Rules/LhsToTeX.js
@@ -13,7 +13,7 @@ export default class LhsToTeX extends Rule {
   ])]
   static description: string = 'Runs lhs2TeX on lhs or lagda files.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     return parameters.some(file => ((file.type === 'LiterateHaskell' && options.literateHaskellEngine === 'lhs2TeX') ||
       (file.type === 'LiterateAgda' && options.literateAgdaEngine === 'lhs2TeX')))
   }

--- a/packages/core/src/Rules/MakeIndex.js
+++ b/packages/core/src/Rules/MakeIndex.js
@@ -20,7 +20,7 @@ export default class MakeIndex extends Rule {
   ]
   static description: string = 'Runs makeindex on any index files.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     const parsedLog: ?ParsedLog = parameters[1].value
     const base = path.basename(parameters[0].filePath)
     const messagePattern = new RegExp(`(Using splitted index at ${base}|Remember to run \\(pdf\\)latex again after calling \`splitindex')`)

--- a/packages/core/src/Rules/MakeIndex.js
+++ b/packages/core/src/Rules/MakeIndex.js
@@ -20,7 +20,7 @@ export default class MakeIndex extends Rule {
   ]
   static description: string = 'Runs makeindex on any index files.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     const parsedLog: ?ParsedLog = parameters[1].value
     const base = path.basename(parameters[0].filePath)
     const messagePattern = new RegExp(`(Using splitted index at ${base}|Remember to run \\(pdf\\)latex again after calling \`splitindex')`)

--- a/packages/core/src/Rules/PdfToPs.js
+++ b/packages/core/src/Rules/PdfToPs.js
@@ -10,7 +10,7 @@ export default class PdfToPs extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['PortableDocumentFormat'])]
   static description: string = 'Converts PDF to PS using pdf2ps. Enabled by the `pdfProducer` option.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     // Only apply if output format is ps
     return options.outputFormat === 'ps'
   }

--- a/packages/core/src/Rules/PdfToPs.js
+++ b/packages/core/src/Rules/PdfToPs.js
@@ -10,7 +10,7 @@ export default class PdfToPs extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['PortableDocumentFormat'])]
   static description: string = 'Converts PDF to PS using pdf2ps. Enabled by the `pdfProducer` option.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     // Only apply if output format is ps
     return options.outputFormat === 'ps'
   }

--- a/packages/core/src/Rules/PsToPdf.js
+++ b/packages/core/src/Rules/PsToPdf.js
@@ -10,7 +10,7 @@ export default class PsToPdf extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['PostScript'])]
   static description: string = 'Converts PS to PDF using ps2pdf.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     // Only apply if output format is pdf
     return options.outputFormat === 'pdf'
   }

--- a/packages/core/src/Rules/PsToPdf.js
+++ b/packages/core/src/Rules/PsToPdf.js
@@ -10,7 +10,7 @@ export default class PsToPdf extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['PostScript'])]
   static description: string = 'Converts PS to PDF using ps2pdf.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     // Only apply if output format is pdf
     return options.outputFormat === 'pdf'
   }

--- a/packages/core/src/Rules/SplitIndex.js
+++ b/packages/core/src/Rules/SplitIndex.js
@@ -16,7 +16,7 @@ export default class SplitIndex extends Rule {
   ]
   static description: string = 'Runs splitindex on any index files.'
 
-  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, parameters: Array<File> = []): Promise<boolean> {
     const parsedLog: ?ParsedLog = parameters[1].value
     const base = path.basename(parameters[0].filePath)
     const messagePattern = new RegExp(`(Using splitted index at ${base}|Remember to run \\(pdf\\)latex again after calling \`splitindex')`)

--- a/packages/core/src/Rules/SplitIndex.js
+++ b/packages/core/src/Rules/SplitIndex.js
@@ -16,7 +16,7 @@ export default class SplitIndex extends Rule {
   ]
   static description: string = 'Runs splitindex on any index files.'
 
-  static async appliesToParameters (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
+  static async isApplicable (state: State, command: Command, phase: Phase, options: OptionsInterface, ...parameters: Array<File>): Promise<boolean> {
     const parsedLog: ?ParsedLog = parameters[1].value
     const base = path.basename(parameters[0].filePath)
     const messagePattern = new RegExp(`(Using splitted index at ${base}|Remember to run \\(pdf\\)latex again after calling \`splitindex')`)

--- a/packages/core/src/State.js
+++ b/packages/core/src/State.js
@@ -141,7 +141,7 @@ export default class State extends EventEmitter {
 
   async addCachedRule (cache: RuleCache): Promise<void> {
     const options = this.getJobOptions(cache.jobName)
-    const id = this.getRuleId(cache.name, cache.command, cache.phase, cache.jobName, ...cache.parameters)
+    const id = this.getRuleId(cache.name, cache.command, cache.phase, cache.jobName, cache.parameters)
     if (this.rules.has(id)) return
 
     const RuleClass = this.ruleClasses.find(ruleClass => ruleClass.name === cache.name)
@@ -153,7 +153,7 @@ export default class State extends EventEmitter {
         parameters.push(parameter)
       }
       // $FlowIgnore
-      const rule = new RuleClass(this, cache.command, cache.phase, options, ...parameters)
+      const rule = new RuleClass(this, cache.command, cache.phase, options, parameters)
       this.addNode(rule.id)
       await rule.initialize()
       this.rules.set(rule.id, rule)
@@ -169,16 +169,13 @@ export default class State extends EventEmitter {
     }
   }
 
-  getRuleId (name: string, command: Command, phase: Phase, jobName: ?string, ...parameters: Array<File | string>): string {
-    const items = parameters.map(item => (typeof item === 'string') ? this.normalizePath(item) : item.filePath)
-    items.unshift(jobName || '')
-    items.unshift(phase || '')
-    items.unshift(command || '')
+  getRuleId (name: string, command: Command, phase: Phase, jobName: ?string, parameters: Array<string> = []): string {
+    const items = [command, phase, jobName || ''].concat(parameters)
     return `${name}(${items.join(';')})`
   }
 
-  getRule (name: string, command: Command, phase: Phase, jobName: ?string, ...parameters: Array<File | string>): ?Rule {
-    const id = this.getRuleId(name, command, phase, jobName, ...parameters)
+  getRule (name: string, command: Command, phase: Phase, jobName: ?string, parameters: Array<string> = []): ?Rule {
+    const id = this.getRuleId(name, command, phase, jobName, parameters)
     return this.rules.get(id)
   }
 

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -255,3 +255,5 @@ pweaveOutputPath: '$JOB.tex',
 severity: 'warning' }
 
 // END_AUTO
+
+export type OptionInterfaceMap = { [name: string]: OptionsInterface }


### PR DESCRIPTION
Unify `appliesToPhase` and `appliesToParameters` so phase based rules don't have to override the super-classes' version.