### PR TITLE
Add dynamic mode to file parsing

### DIFF
--- a/packages/core/src/File.js
+++ b/packages/core/src/File.js
@@ -11,9 +11,8 @@ import yaml from 'js-yaml'
 
 import type { FileType, Parser, Reference } from './types'
 
-export const DEFAULT_PARSING_MODE = 'default'
-
 export default class File {
+  static DEFAULT_PARSING_MODE = 'default'
   static fileTypes: Map<string, FileType>
 
   // The complete and real file path in the file system.
@@ -104,7 +103,7 @@ export default class File {
       let modeParsers: Array<Parser> = []
       const setMode = newMode => {
         mode = newMode
-        modeParsers = parsers.filter(parser => (parser.modes || [DEFAULT_PARSING_MODE]).includes(mode))
+        modeParsers = parsers.filter(parser => (parser.modes || [File.DEFAULT_PARSING_MODE]).includes(mode))
       }
       // A function to check form matches in all the parsers.
       const checkForMatches = (finalCheck: boolean = false) => {
@@ -160,7 +159,7 @@ export default class File {
         }
       }
 
-      setMode(DEFAULT_PARSING_MODE)
+      setMode(File.DEFAULT_PARSING_MODE)
 
       if (this.virtual) {
         const rawLines = this.value ? this.value.toString().split(/\r?\n/) : []

--- a/packages/core/src/Rules/ParseAsymptoteStdOut.js
+++ b/packages/core/src/Rules/ParseAsymptoteStdOut.js
@@ -26,19 +26,19 @@ export default class ParseAsymptoteStdOut extends Rule {
     await this.firstParameter.parse([{
       names: ['filePath'],
       patterns: [/^cd (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         rootPath = groups.filePath
       }
     }, {
       names: ['filePath'],
       patterns: [/^Wrote (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.outputs.push(this.normalizePath(path.resolve(rootPath, groups.filePath)))
       }
     }, {
       names: ['type', 'filePath'],
       patterns: [/^(Including|Loading) \S+ from (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         if (!path.isAbsolute(groups.filePath)) {
           parsedLog.inputs.push(this.normalizePath(path.resolve(rootPath, groups.filePath)))
         }

--- a/packages/core/src/Rules/ParseBibTeXLog.js
+++ b/packages/core/src/Rules/ParseBibTeXLog.js
@@ -28,7 +28,7 @@ export default class ParseBibTeXLog extends Rule {
       // Missing database files or missing cross references.
       names: ['text'],
       patterns: [/^(I couldn't open (?:auxiliary|database) file .*|A bad cross reference---entry .*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           severity: 'error',
           name,
@@ -40,7 +40,7 @@ export default class ParseBibTeXLog extends Rule {
       // Warning messages
       names: ['text'],
       patterns: [/^Warning--(.+)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           severity: 'warning',
           name,
@@ -52,7 +52,7 @@ export default class ParseBibTeXLog extends Rule {
       // Continued source references.
       names: ['line', 'file'],
       patterns: [/^-+line (\d+) of file (.+)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const message = parsedLog.messages[parsedLog.messages.length - 1]
         if (message) {
           const line = parseInt(groups.line, 10)
@@ -74,7 +74,7 @@ export default class ParseBibTeXLog extends Rule {
       // Error messages with a source reference.
       names: ['text', 'line', 'file'],
       patterns: [/^(.+)---line (\d+) of file (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const line = parseInt(groups.line, 10)
         parsedLog.messages.push({
           severity: 'error',
@@ -96,7 +96,7 @@ export default class ParseBibTeXLog extends Rule {
       // line.
       names: ['input'],
       patterns: [/^.*?(?:Database file #\d+|The style file|The top-level auxiliary file|A level-\d+ auxiliary file): (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.inputs.push(groups.input)
       }
     }])

--- a/packages/core/src/Rules/ParseBibToGlsLog.js
+++ b/packages/core/src/Rules/ParseBibToGlsLog.js
@@ -24,13 +24,13 @@ export default class ParseBibTeXLog extends Rule {
     await this.firstParameter.parse([{
       names: ['output'],
       patterns: [/^Writing (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.outputs.push(this.normalizePath(groups.output))
       }
     }, {
       names: ['input'],
       patterns: [/^Reading (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.inputs.push(this.normalizePath(groups.input))
       }
     }])

--- a/packages/core/src/Rules/ParseBiberLog.js
+++ b/packages/core/src/Rules/ParseBiberLog.js
@@ -25,7 +25,7 @@ export default class ParseBiberLog extends Rule {
       // Input messages
       names: ['text', 'input'],
       patterns: [/^[^>]+> INFO - ((?:Found BibTeX data source|Reading) '([^']+)')$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.inputs.push(groups.input)
 
         const message: Message = {
@@ -41,7 +41,7 @@ export default class ParseBiberLog extends Rule {
       // Output messages
       names: ['text', 'output'],
       patterns: [/^[^>]+> INFO - ((?:Writing|Logfile is) '([^']+)'.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.outputs.push(groups.output)
 
         const message: Message = {
@@ -57,7 +57,7 @@ export default class ParseBiberLog extends Rule {
       // All other messages
       names: ['severity', 'text'],
       patterns: [/^[^>]+> (INFO|WARN|ERROR) - (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         let severity = 'error'
         switch (groups.severity) {
           case 'INFO':

--- a/packages/core/src/Rules/ParseFileListing.js
+++ b/packages/core/src/Rules/ParseFileListing.js
@@ -26,13 +26,13 @@ export default class ParseFileListing extends Rule {
     await this.firstParameter.parse([{
       names: ['path'],
       patterns: [/^PWD (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         rootPath = groups.path
       }
     }, {
       names: ['type', 'path'],
       patterns: [/^(INPUT|OUTPUT) (.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const candidate = this.normalizePath(path.resolve(rootPath, groups.path))
         const items = groups.type === 'INPUT' ? parsedLog.inputs : parsedLog.outputs
         if (!items.includes(candidate)) items.push(candidate)

--- a/packages/core/src/Rules/ParseKnitrConcordance.js
+++ b/packages/core/src/Rules/ParseKnitrConcordance.js
@@ -23,7 +23,7 @@ export default class ParseKnitrConcordance extends Rule {
     await this.firstParameter.parse([{
       names: ['output', 'input', 'indicies'],
       patterns: [/^\\Sconcordance\{concordance:([^:]*):([^:]*):([^}]*)\}$/],
-      evaluate: (references, groups) => {
+      evaluate: (mode, reference, groups) => {
         // Split up the indicies in preparation to decode the RLE array.
         const encodedIndicies: Array<number> = groups.indicies.split(/\s+/).map(x => parseInt(x))
         const mappings: Array<LineRangeMapping> = []

--- a/packages/core/src/Rules/ParseLaTeXAuxilary.js
+++ b/packages/core/src/Rules/ParseLaTeXAuxilary.js
@@ -22,7 +22,7 @@ export default class ParseLaTeXAuxilary extends Rule {
     await this.firstParameter.parse([{
       names: ['command'],
       patterns: [/^\\([A-Za-z@]+)/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         results.commands.push(groups.command)
       }
     }])

--- a/packages/core/src/Rules/ParseLaTeXLog.js
+++ b/packages/core/src/Rules/ParseLaTeXLog.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import File from '../File'
 import Rule from '../Rule'
 import Log from '../Log'
 
@@ -7,7 +8,7 @@ import type { Action, Command, Message, ParsedLog } from '../types'
 
 const WRAPPED_LINE_PATTERN = /^.{76}[^.]{3}$/
 
-const LATEX3_MODE = 'latex3'
+const LATEX3_PARSING_MODE = 'latex3'
 
 export default class ParseLaTeXLog extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['LaTeXLog'])]
@@ -173,7 +174,7 @@ export default class ParseLaTeXLog extends Rule {
 
         parsedLog.messages.push(message)
 
-        return LATEX3_MODE
+        return LATEX3_PARSING_MODE
       }
     }, {
       // LaTeX3 messages
@@ -194,11 +195,11 @@ export default class ParseLaTeXLog extends Rule {
 
         parsedLog.messages.push(message)
 
-        return LATEX3_MODE
+        return LATEX3_PARSING_MODE
       }
     }, {
       // LaTeX3 continued message
-      modes: [LATEX3_MODE],
+      modes: [LATEX3_PARSING_MODE],
       names: ['text', 'line'],
       patterns: [/^[.*!] (.*?)(?: on line (\d+)\.?)?$/],
       evaluate: (mode, reference, groups) => {
@@ -226,7 +227,7 @@ export default class ParseLaTeXLog extends Rule {
       }
     }, {
       // End of LaTeX3 message
-      modes: [LATEX3_MODE],
+      modes: [LATEX3_PARSING_MODE],
       names: [],
       patterns: [/^[.*!]{48,50} *$/],
       evaluate: (mode, reference, groups) => {
@@ -236,7 +237,7 @@ export default class ParseLaTeXLog extends Rule {
           message.log.range.end = reference.range.end
         }
 
-        return 'default'
+        return File.DEFAULT_PARSING_MODE
       }
     }, {
       // Missing file warning.

--- a/packages/core/src/Rules/ParseLaTeXLog.js
+++ b/packages/core/src/Rules/ParseLaTeXLog.js
@@ -7,6 +7,8 @@ import type { Action, Command, Message, ParsedLog } from '../types'
 
 const WRAPPED_LINE_PATTERN = /^.{76}[^.]{3}$/
 
+const LATEX3_MODE = 'latex3'
+
 export default class ParseLaTeXLog extends Rule {
   static parameterTypes: Array<Set<string>> = [new Set(['LaTeXLog'])]
   static commands: Set<Command> = new Set(['build', 'log'])
@@ -34,12 +36,12 @@ export default class ParseLaTeXLog extends Rule {
     await this.firstParameter.parse([{
       // Ignore intro line
       patterns: [/^This is/],
-      evaluate: (reference, groups) => {}
+      evaluate: (mode, reference, groups) => {}
     }, {
       // Input file name
       names: ['filePath'],
       patterns: [/^\*\*([^*]+)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         // Don't let subsequent lines overwrite the first.
         if (!sourcePaths.length === 0) {
           sourcePaths.unshift(this.normalizePath(groups.filePath))
@@ -49,7 +51,7 @@ export default class ParseLaTeXLog extends Rule {
       // Package info message
       names: ['text'],
       patterns: [/^Package: (.*)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: 'info',
@@ -63,7 +65,7 @@ export default class ParseLaTeXLog extends Rule {
       // included.
       names: ['category', 'text'],
       patterns: [/^! (.+) Error: (.+?)\.?$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           severity: 'error',
           name,
@@ -78,7 +80,7 @@ export default class ParseLaTeXLog extends Rule {
       // available.
       names: ['file', 'line', 'category', 'text'],
       patterns: [/^(\S.*):(\d+): (?:(.+) Error: )?(.+?)\.?$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const line: number = parseInt(groups.line, 10)
         const message: Message = {
           severity: 'error',
@@ -99,7 +101,7 @@ export default class ParseLaTeXLog extends Rule {
       // Warning/Info messages, possibly with a line reference.
       names: ['category', 'severity', 'text', 'line'],
       patterns: [/^(.+) (Warning|Info): +(.*?)(?: on input line (\d+)\.)?$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const message: Message = {
           severity: groups.severity.toLowerCase(),
           name,
@@ -125,7 +127,7 @@ export default class ParseLaTeXLog extends Rule {
       // Continuation of message with possible file reference.
       names: ['package', 'text', 'line'],
       patterns: [/^\(([^()]+)\) {2,}(.*?)(?: on input line (\d+)\.?)?$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const message: Message = parsedLog.messages[parsedLog.messages.length - 1]
         // Verify that the previous message matches the category.
         if (message && message.category && message.category.endsWith(groups.package)) {
@@ -154,7 +156,7 @@ export default class ParseLaTeXLog extends Rule {
         /^!$/,
         /^(.*):(\d+): (?:(.+) error: )?(.+?)\.?$/
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const line: number = parseInt(groups.line, 10)
         const message: Message = {
           severity: 'error',
@@ -170,6 +172,8 @@ export default class ParseLaTeXLog extends Rule {
         if (groups.category) message.category = groups.category
 
         parsedLog.messages.push(message)
+
+        return LATEX3_MODE
       }
     }, {
       // LaTeX3 messages
@@ -178,7 +182,7 @@ export default class ParseLaTeXLog extends Rule {
         /^[.*!]{48,50}$/,
         /^[.*!] (.*?) (info|warning|error): ("[^"]*")$/
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const message: Message = {
           severity: groups.severity,
           name,
@@ -189,12 +193,15 @@ export default class ParseLaTeXLog extends Rule {
         }
 
         parsedLog.messages.push(message)
+
+        return LATEX3_MODE
       }
     }, {
       // LaTeX3 continued message
+      modes: [LATEX3_MODE],
       names: ['text', 'line'],
       patterns: [/^[.*!] (.*?)(?: on line (\d+)\.?)?$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const message: Message = parsedLog.messages[parsedLog.messages.length - 1]
         if (message && message.log && message.log.range && reference.range) {
           // Don't add input requests to the message.
@@ -219,20 +226,23 @@ export default class ParseLaTeXLog extends Rule {
       }
     }, {
       // End of LaTeX3 message
+      modes: [LATEX3_MODE],
       names: [],
       patterns: [/^[.*!]{48,50} *$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const message: Message = parsedLog.messages[parsedLog.messages.length - 1]
         // If the the previous message has a log reference then extend it.
         if (message && message.log && message.log.range && reference.range) {
           message.log.range.end = reference.range.end
         }
+
+        return 'default'
       }
     }, {
       // Missing file warning.
       names: ['text'],
       patterns: [/^(No file .*\.)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           severity: 'warning',
           name,
@@ -244,7 +254,7 @@ export default class ParseLaTeXLog extends Rule {
       // makeidx/splitidx messages.
       names: ['text'],
       patterns: [/^(Writing index file.*|Using splitted index at.*|Started index file .*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           severity: 'info',
           name,
@@ -257,7 +267,7 @@ export default class ParseLaTeXLog extends Rule {
       // it does not put the output PDF file name into the FLS file.
       names: ['filePath'],
       patterns: [/^Output written on "?([^"]+)"? \([^)]*\)\.$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         // Sometimes XeLaTeX uses astricks instead of spaces in output path.
         parsedLog.outputs.push(this.normalizePath(groups.filePath.replace(/\*/g, ' ')))
       }
@@ -265,13 +275,13 @@ export default class ParseLaTeXLog extends Rule {
       // Run system message.
       names: ['command', 'status'],
       patterns: [/^runsystem\((.*?)\)\.\.\.(.*?)\.$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.calls.push(Log.parseCall(groups.command, groups.status))
       }
     }, {
       // \input notification
       patterns: [/(\([^()[]+|\))/g],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const trimPattern = /(^\([\s"]*|[\s"]+$)/g
         for (const token of groups.captures) {
           if (token === ')') {

--- a/packages/core/src/Rules/ParseLaTeXMagic.js
+++ b/packages/core/src/Rules/ParseLaTeXMagic.js
@@ -26,7 +26,7 @@ export default class ParseLaTeXMagic extends Rule {
     await this.firstParameter.parse([{
       names: ['jobName', 'name', 'value'],
       patterns: [/^%\s*!T[eE]X\s+(?:([^:]+?)\s*:\s*)?(\$?\w+)\s*=\s*(.*?)\s*$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const schema = this.state.optionSchema.get(groups.name)
         let value = groups.value
 

--- a/packages/core/src/Rules/ParseMakeIndexLog.js
+++ b/packages/core/src/Rules/ParseMakeIndexLog.js
@@ -29,7 +29,7 @@ export default class ParseMakeIndexLog extends Rule {
       patterns: [
         /^Scanning (?:style|input) file (.*?)[.]+done .*$/
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.inputs.push(this.normalizePath(groups.input))
         parsedLog.messages.push({
           severity: 'info',
@@ -43,7 +43,7 @@ export default class ParseMakeIndexLog extends Rule {
       patterns: [
         /^(?:Output|Transcript) written in (.*?)\.*$/
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.outputs.push(this.normalizePath(groups.output))
         parsedLog.messages.push({
           severity: 'info',
@@ -57,7 +57,7 @@ export default class ParseMakeIndexLog extends Rule {
       patterns: [
         /^(Nothing written in .*?\.)$/
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           severity: 'warning',
           name,
@@ -70,7 +70,7 @@ export default class ParseMakeIndexLog extends Rule {
       patterns: [
         /^(Sorting entries.*)$/
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           severity: 'info',
           name,
@@ -84,7 +84,7 @@ export default class ParseMakeIndexLog extends Rule {
         /## Warning \(input = (.+), line = (\d+); output = (.+), line = (\d+)\):/,
         MESSAGE_PATTERN
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const line = parseInt(groups.inputLine, 10)
         parsedLog.messages.push({
           severity: 'warning',
@@ -106,7 +106,7 @@ export default class ParseMakeIndexLog extends Rule {
         /^[*!]+ (Input (?:index|style)) error \(file = (.+), line = (\d+)\):$/,
         MESSAGE_PATTERN
       ],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const line = parseInt(groups.line, 10)
         parsedLog.messages.push({
           severity: 'error',

--- a/packages/core/src/Rules/ParseMendexLog.js
+++ b/packages/core/src/Rules/ParseMendexLog.js
@@ -34,7 +34,7 @@ export default class ParsedMendexLog extends Rule {
       // Error/Warning messages
       names: ['severity', 'text', 'file', 'line'],
       patterns: [/^(Error|Warning): (.*?)(?: in (.*?), line ([0-9]+))?\.$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const message: Message = {
           name,
           severity: groups.severity.toLowerCase(),
@@ -59,7 +59,7 @@ export default class ParsedMendexLog extends Rule {
       // Bad encap messages
       names: ['text', 'file', 'line'],
       patterns: [/^Bad encap string in (.*?), line ([0-9]+)\.$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const line: number = parseInt(groups.line, 10)
         parsedLog.messages.push({
           name,
@@ -76,7 +76,7 @@ export default class ParsedMendexLog extends Rule {
       // Coallator failure
       names: ['text'],
       patterns: [/^(\[ICU\] Collator creation failed.*)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: 'error',
@@ -89,7 +89,7 @@ export default class ParsedMendexLog extends Rule {
       // Entry report
       names: ['text'],
       patterns: [/^(.*? entries accepted, .*? rejected\.)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: 'info',
@@ -102,7 +102,7 @@ export default class ParsedMendexLog extends Rule {
       // Input files
       names: ['file'],
       patterns: [/^Scanning (?:dictionary|environment dictionary|input) file (.*?)\.$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.inputs.push(path.normalize(groups.file))
         parsedLog.messages.push({
           name,
@@ -116,7 +116,7 @@ export default class ParsedMendexLog extends Rule {
       // Output files
       names: ['file'],
       patterns: [/^Output written in (.*?)\.$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.outputs.push(path.normalize(groups.file))
         parsedLog.messages.push({
           name,

--- a/packages/core/src/Rules/ParseMendexStdErr.js
+++ b/packages/core/src/Rules/ParseMendexStdErr.js
@@ -31,14 +31,14 @@ export default class ParsedMendexStdErr extends Rule {
       // Get the name
       names: ['text'],
       patterns: [/^This is (upmendex|mendex) /i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         name = groups.name
       }
     }, {
       // Dictionary Error
       names: ['name', 'text'],
       patterns: [/^(upmendex|mendex): (.*? is forbidden to open for reading\.)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name: groups.name,
           severity: 'error',
@@ -49,7 +49,7 @@ export default class ParsedMendexStdErr extends Rule {
       // Missing file errors
       names: ['text'],
       patterns: [/^(No log file, .*?\.|.*? does not exist\.)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: 'error',
@@ -60,7 +60,7 @@ export default class ParsedMendexStdErr extends Rule {
       // Bad kanji encoding
       names: ['text'],
       patterns: [/^(Ignoring bad kanji encoding.*)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: 'warning',

--- a/packages/core/src/Rules/ParseSplitIndexStdErr.js
+++ b/packages/core/src/Rules/ParseSplitIndexStdErr.js
@@ -25,7 +25,7 @@ export default class ParseSplitIndexStdOut extends Rule {
       // parse anything that has that form.
       names: ['text', 'file', 'line'],
       patterns: [/^(.*) at (.*?) line ([0-9]+)\.$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         const line = parseInt(groups.line, 10)
 
         // Do not include the log reference since it is to a virtual file.

--- a/packages/core/src/Rules/ParseSplitIndexStdOut.js
+++ b/packages/core/src/Rules/ParseSplitIndexStdOut.js
@@ -25,7 +25,7 @@ export default class ParseSplitIndexStdOut extends Rule {
     await this.firstParameter.parse([{
       names: ['text'],
       patterns: [/^(Close.*|New index file.*)$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         // Do not include the reference since it is to a virtual file.
         parsedLog.messages.push({
           severity: 'info',
@@ -36,7 +36,7 @@ export default class ParseSplitIndexStdOut extends Rule {
     }, {
       names: ['filePath'],
       patterns: [/^(.*?) with [0-9]+ lines$/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         // Do not include the reference since it is to a virtual file.
         parsedLog.messages.push({
           severity: 'info',

--- a/packages/core/src/Rules/ParseXindyLog.js
+++ b/packages/core/src/Rules/ParseXindyLog.js
@@ -34,7 +34,7 @@ export default class ParsedXindyLog extends Rule {
       // Error/Warning messages with file references
       names: ['severity', 'text', 'file'],
       patterns: [/^(ERROR|WARNING): (.*? in:?)$/i, /(.*)/],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: groups.severity.toLowerCase(),
@@ -47,7 +47,7 @@ export default class ParsedXindyLog extends Rule {
       // Error/Warning messages
       names: ['severity', 'text'],
       patterns: [/^(ERROR|WARNING): (.*)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: groups.severity.toLowerCase(),
@@ -60,7 +60,7 @@ export default class ParsedXindyLog extends Rule {
       // Module loadings
       names: ['text'],
       patterns: [/^(Loading module .*|Finished loading module .*)$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.messages.push({
           name,
           severity: 'info',
@@ -73,7 +73,7 @@ export default class ParsedXindyLog extends Rule {
       // Input files
       names: ['file'],
       patterns: [/^Reading raw-index (.*?)[.]{3}$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         filePath = path.normalize(groups.file)
         parsedLog.inputs.push(path.normalize(groups.file))
         parsedLog.messages.push({
@@ -88,7 +88,7 @@ export default class ParsedXindyLog extends Rule {
       // Output files
       names: ['file'],
       patterns: [/^(?:Markup written into file|Opening logfile) (.*?)[. ]$/i],
-      evaluate: (reference, groups) => {
+      evaluate: (mode, reference, groups) => {
         parsedLog.outputs.push(path.normalize(groups.file))
         parsedLog.messages.push({
           name,

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -62,9 +62,10 @@ export type Reference = {
 }
 
 export type Parser = {
+  modes?: Array<string>,
   names?: Array<string>,
   patterns: Array<RegExp>,
-  evaluate: (reference: Reference, groups: Object) => void
+  evaluate: (mode: string, reference: Reference, groups: Object) => ?string
 }
 
 export type Severity = 'info' | 'warning' | 'error'


### PR DESCRIPTION
LaTeX3 messages can be a variable number of lines. Although the current parsing algorithm captures the messages, sometimes the middle pattern of `/^[.!*] /` is capturing non-LaTeX3 messages. Adding a mode parameter so patterns can be scoped based on current state.