### PR TITLE
Add readonly files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 -   Regression which prevented output directory from being created.
+-   Instance options set from the command line or passed to the library
+    interface are now protected from cache cleaning.
 
 ## [v0.11.0][] — 2017-10-25
 

--- a/packages/core/src/DiCy.ts
+++ b/packages/core/src/DiCy.ts
@@ -46,7 +46,13 @@ export default class DiCy extends StateConsumer {
 
   async setInstanceOptions (options: Object = {}) {
     const instance = await this.getFile('dicy-instance.yaml-ParsedYAML')
-    if (instance) instance.value = options
+    if (instance) {
+      instance.readOnly = false
+      instance.value = options
+      instance.readOnly = true
+    } else {
+      this.error('Unable to set instance options.')
+    }
   }
 
   async analyzePhase (command: Command, phase: Phase) {

--- a/packages/core/src/File.ts
+++ b/packages/core/src/File.ts
@@ -26,6 +26,8 @@ export default class File {
   // If it is a virtual or a physical file. Virtual files are usually in-memory
   // copies of parsed files such as log files.
   virtual: boolean = false
+  // Read only files cannot be deleted nor have their value changed
+  readOnly: boolean = false
   // A hash of the file contents. Used to verify that file has actually changed
   // when the timestamp changes
   hash: string
@@ -316,6 +318,7 @@ export default class File {
   }
 
   set value (value: any | undefined) {
+    if (this.readOnly) return
     if (!_.isEqual(value, this._value)) {
       this.hasBeenUpdated = true
       this.timeStamp = new Date()

--- a/packages/core/src/Rules/ApplyOptions.ts
+++ b/packages/core/src/Rules/ApplyOptions.ts
@@ -54,6 +54,7 @@ export default class ApplyOptions extends Rule {
     for (const options of optionSet) {
       this.assignOptions(options)
     }
+    console.log(this.state.options)
   }
 
   checkForConfigurationChange (previousOptions: Object): void {

--- a/packages/core/src/Rules/ApplyOptions.ts
+++ b/packages/core/src/Rules/ApplyOptions.ts
@@ -54,7 +54,6 @@ export default class ApplyOptions extends Rule {
     for (const options of optionSet) {
       this.assignOptions(options)
     }
-    console.log(this.state.options)
   }
 
   checkForConfigurationChange (previousOptions: Object): void {

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -217,6 +217,8 @@ export default class State extends EventEmitter {
   }
 
   async deleteFile (file: File, jobName: string | undefined, unlink: boolean = true) {
+    if (file.readOnly) return
+
     const invalidRules: Rule[] = []
 
     for (const rule of this.rules.values()) {


### PR DESCRIPTION
The virtual file used for instance options (`dicy-instance.yaml-ParsedYAML`) is getting deleted by `LoadAndValidateCache` when cleaning the cache. Add a `readOnly` property to `File` to protect certain files.