### PR TITLE
Fix copy targets

### DIFF
--- a/packages/core/spec/Builder_spec.ts
+++ b/packages/core/spec/Builder_spec.ts
@@ -75,5 +75,28 @@ describe('Builder', () => {
 
       done()
     })
+
+    it('Correctly rebuilds if outputs have been removed with copy targets enabled.', async (done) => {
+      const filePath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.tex')
+      const outputPath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.pdf')
+      const outputDirectory: string = path.join(fixturesPath, 'cache-tests', 'output')
+      let messages: Message[] = []
+      dicy = await Builder.create(filePath)
+      dicy.on('log', (newMessages: Message[]) => { messages = messages.concat(newMessages) })
+
+      expect(await dicy.run(['load', 'build', 'save'])).toBeTrue()
+      expect(messages).toReceiveMessages([])
+      expect(await fs.pathExists(outputPath)).toBeTrue()
+
+      messages = []
+      await fs.remove(outputPath)
+      await fs.remove(outputDirectory)
+
+      expect(await dicy.run(['load', 'build'])).toBeTrue()
+      expect(messages).toReceiveMessages([])
+      expect(await fs.pathExists(outputPath)).toBeTrue()
+
+      done()
+    })
   })
 })

--- a/packages/core/spec/Builder_spec.ts
+++ b/packages/core/spec/Builder_spec.ts
@@ -14,7 +14,6 @@ import { cloneFixtures, customMatchers, formatMessage } from './helpers'
 const ASYNC_TIMEOUT = 50000
 
 describe('Builder', () => {
-  let dicy: Builder
   let fixturesPath: string
 
   beforeEach(async (done) => {
@@ -24,6 +23,7 @@ describe('Builder', () => {
   })
 
   describe('can successfully build', () => {
+    let dicy: Builder
     const testPath: string = path.join(__dirname, 'fixtures', 'builder-tests')
     let tests: Array<string> = readdir.sync(testPath, { filter: /\.(lhs|tex|Rnw|lagda|Pnw)$/i })
 
@@ -62,69 +62,115 @@ describe('Builder', () => {
     }
   })
 
-  describe('Caching functionality', () => {
-    it('Correctly loads and validates cache if outputs have been removed with copy targets enabled.', async (done) => {
-      const filePath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.tex')
-      const outputPath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.pdf')
-      const outputUrl: string = fileUrl(outputPath)
-      let messages: Message[] = []
-      dicy = await Builder.create(filePath)
-      dicy.on('log', (newMessages: Message[]) => { messages = messages.concat(newMessages) })
+  describe('caching facility', () => {
+    let filePath: string
+    let intermediateOutputPath: string
+    let outputDirectory: string
+    let outputPath: string
+    let outputUrl: string
+    let primaryMessages: Message[]
+    let primaryBuilder: Builder
+    let secondaryMessages: Message[]
+    let secondaryBuilder: Builder
 
-      expect(await dicy.run(['load', 'build'])).toBeTrue()
-      expect(messages).toReceiveMessages([])
-      expect(await fs.pathExists(outputPath)).toBeTrue()
-      expect(await dicy.getTargets()).toEqual([outputUrl])
+    beforeEach(async (done) => {
+      filePath = path.join(fixturesPath, 'cache-tests', 'copy-targets.tex')
+      intermediateOutputPath = path.join(fixturesPath, 'cache-tests', 'output', 'copy-targets.pdf')
+      outputDirectory = path.join(fixturesPath, 'cache-tests', 'output')
+      outputPath = path.join(fixturesPath, 'cache-tests', 'copy-targets.pdf')
+      outputUrl = fileUrl(outputPath)
+
+      primaryMessages = []
+      primaryBuilder = await Builder.create(filePath)
+      primaryBuilder.on('log', (newMessages: Message[]) => { primaryMessages = primaryMessages.concat(newMessages) })
+
+      secondaryMessages = []
+      secondaryBuilder = await Builder.create(filePath)
+      secondaryBuilder.on('log', (newMessages: Message[]) => { secondaryMessages = secondaryMessages.concat(newMessages) })
 
       done()
     })
 
-    it('Correctly rebuilds if outputs have been removed with copy targets enabled.', async (done) => {
-      const filePath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.tex')
-      const outputPath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.pdf')
-      const outputDirectory: string = path.join(fixturesPath, 'cache-tests', 'output')
-      const outputUrl: string = fileUrl(outputPath)
-      let messages: Message[] = []
-      dicy = await Builder.create(filePath)
-      dicy.on('log', (newMessages: Message[]) => { messages = messages.concat(newMessages) })
-
-      expect(await dicy.run(['load', 'build', 'save'])).toBeTrue()
-      expect(messages).toReceiveMessages([])
+    it('loads and validates cache if outputs have been removed with copy targets enabled.', async (done) => {
+      expect(await primaryBuilder.run(['load', 'build'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
       expect(await fs.pathExists(outputPath)).toBeTrue()
-      expect(await dicy.getTargets()).toEqual([outputUrl])
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
 
-      messages = []
+      done()
+    })
+
+    it('rebuilds if all outputs have been removed with copy targets enabled.', async (done) => {
+      expect(await primaryBuilder.run(['load', 'build', 'save'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
+      expect(await fs.pathExists(outputPath)).toBeTrue()
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
+
+      primaryMessages = []
       await fs.remove(outputPath)
       await fs.remove(outputDirectory)
 
-      expect(await dicy.run(['load', 'build'])).toBeTrue()
-      expect(messages).toReceiveMessages([])
+      expect(await primaryBuilder.run(['load', 'build'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
       expect(await fs.pathExists(outputPath)).toBeTrue()
-      expect(await dicy.getTargets()).toEqual([outputUrl])
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
 
       done()
     })
 
-    it('Correctly produces targets if a new builder is created.', async (done) => {
-      const filePath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.tex')
-      const outputPath: string = path.join(fixturesPath, 'cache-tests', 'copy-targets.pdf')
-      const outputUrl: string = fileUrl(outputPath)
-      let messages: Message[] = []
-
-      dicy = await Builder.create(filePath)
-      dicy.on('log', (newMessages: Message[]) => { messages = messages.concat(newMessages) })
-      expect(await dicy.run(['load', 'build', 'save'])).toBeTrue()
-      expect(messages).toReceiveMessages([])
+    it('rebuilds if target has been removed with copy targets enabled.', async (done) => {
+      expect(await primaryBuilder.run(['load', 'build', 'save'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
       expect(await fs.pathExists(outputPath)).toBeTrue()
-      expect(await dicy.getTargets()).toEqual([outputUrl])
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
 
-      messages = []
-      dicy = await Builder.create(filePath)
-      dicy.on('log', (newMessages: Message[]) => { messages = messages.concat(newMessages) })
-      expect(await dicy.run(['load'])).toBeTrue()
-      expect(messages).toReceiveMessages([])
+      primaryMessages = []
+      await fs.remove(outputPath)
+
+      expect(await primaryBuilder.run(['load', 'build'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
       expect(await fs.pathExists(outputPath)).toBeTrue()
-      expect(await dicy.getTargets()).toEqual([outputUrl])
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
+
+      done()
+    })
+
+    it('rebuilds if output directory has been removed with copy targets enabled.', async (done) => {
+      expect(await primaryBuilder.run(['load', 'build', 'save'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(outputPath)).toBeTrue()
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
+
+      primaryMessages = []
+      await fs.remove(outputDirectory)
+
+      expect(await primaryBuilder.run(['load', 'build'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
+      expect(await fs.pathExists(outputPath)).toBeTrue()
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
+
+      done()
+    })
+
+    it('produces targets if a new builder is created.', async (done) => {
+      expect(await primaryBuilder.run(['load', 'build', 'save'])).toBeTrue()
+      expect(primaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
+      expect(await fs.pathExists(outputPath)).toBeTrue()
+      expect(await primaryBuilder.getTargets()).toEqual([outputUrl])
+
+      expect(await secondaryBuilder.run(['load'])).toBeTrue()
+      expect(secondaryMessages).toReceiveMessages([])
+      expect(await fs.pathExists(intermediateOutputPath)).toBeTrue()
+      expect(await fs.pathExists(outputPath)).toBeTrue()
+      expect(await secondaryBuilder.getTargets()).toEqual([outputUrl])
 
       done()
     })

--- a/packages/core/spec/Rules/Agda_spec.ts
+++ b/packages/core/spec/Rules/Agda_spec.ts
@@ -42,7 +42,11 @@ describe('Agda', () => {
         args: ['agda', '--latex', '--latex-dir=.', '{{$BASE_0}}'],
         cd: '$ROOTDIR/$DIR_0',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.tex', '$DIR_0/$NAME_0.agdai', '$DIR_0/agda.sty']
+        outputs: [
+          { file: '$DIR_0/$NAME_0.tex' },
+          { file: '$DIR_0/$NAME_0.agdai' },
+          { file: '$DIR_0/agda.sty' }
+        ]
       })
 
       done()

--- a/packages/core/spec/Rules/Asymptote_spec.ts
+++ b/packages/core/spec/Rules/Asymptote_spec.ts
@@ -48,13 +48,11 @@ describe('Asymptote', () => {
         args: ['asy', '-vv', '{{$BASE_0}}'],
         cd: '$ROOTDIR_0',
         severity: 'error',
-        inputs: [
-          '$DIR_0/$NAME_0.log-ParsedAsymptoteStdOut'
-        ],
+        inputs: [{ file: '$DIR_0/$NAME_0.log-ParsedAsymptoteStdOut' }],
         outputs: [
-          '$DIR_0/${NAME_0}_0.pdf',
-          '$DIR_0/${NAME_0}_0.eps',
-          '$DIR_0/$NAME_0.pre'
+          { file: '$DIR_0/${NAME_0}_0.pdf' },
+          { file: '$DIR_0/${NAME_0}_0.eps' },
+          { file: '$DIR_0/$NAME_0.pre' }
         ],
         stdout: '$DIR_0/$NAME_0.log-AsymptoteStdOut',
         stderr: '$DIR_0/$NAME_0.log-AsymptoteStdErr'

--- a/packages/core/spec/Rules/BibTeX_spec.ts
+++ b/packages/core/spec/Rules/BibTeX_spec.ts
@@ -103,7 +103,7 @@ describe('BibTeX', () => {
         args: ['bibtex', '{{$BASE_0}}'],
         cd: '$ROOTDIR/$DIR_0',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.bbl', '$DIR_0/$NAME_0.blg']
+        outputs: [{ file: '$DIR_0/$NAME_0.bbl' }, { file: '$DIR_0/$NAME_0.blg' }]
       })
 
       done()

--- a/packages/core/spec/Rules/BibToGls_spec.ts
+++ b/packages/core/spec/Rules/BibToGls_spec.ts
@@ -67,8 +67,8 @@ describe('BibToGls', () => {
         args: ['bib2gls', '-t', '{{$NAME_0.gelg}}', '{{$NAME_0}}'],
         cd: '$ROOTDIR',
         severity: 'error',
-        inputs: ['$DIR_0/$NAME_0.gelg-ParsedBibToGlsLog'],
-        outputs: ['$DIR_0/$NAME_0.gelg']
+        inputs: [{ file: '$DIR_0/$NAME_0.gelg-ParsedBibToGlsLog' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.gelg' }]
       })
 
       done()

--- a/packages/core/spec/Rules/Biber_spec.ts
+++ b/packages/core/spec/Rules/Biber_spec.ts
@@ -83,7 +83,7 @@ describe('Biber', () => {
         args: ['biber', '{{$FILEPATH_0}}'],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.bbl', '$DIR_0/$NAME_0.blg']
+        outputs: [{ file: '$DIR_0/$NAME_0.bbl' }, { file: '$DIR_0/$NAME_0.blg' }]
       })
 
       done()

--- a/packages/core/spec/Rules/CopyTargetsToRoot_spec.ts
+++ b/packages/core/spec/Rules/CopyTargetsToRoot_spec.ts
@@ -12,9 +12,8 @@ async function initialize ({
   parameters = [{
     filePath: 'file-types/PortableDocumentFormat.pdf'
   }],
-  targets = ['file-types/PortableDocumentFormat.pdf'],
   ...rest }: RuleDefinition = {}) {
-  return initializeRule({ RuleClass, filePath, parameters, targets, ...rest })
+  return initializeRule({ RuleClass, filePath, parameters, ...rest })
 }
 
 describe('CopyTargetsToRoot', () => {
@@ -76,19 +75,6 @@ describe('CopyTargetsToRoot', () => {
     })
   })
 
-  describe('initialize', () => {
-    it('replaces input target with destination path', async (done) => {
-      const { rule } = await initialize({
-        options: { copyTargetsToRoot: true }
-      })
-
-      expect(rule.state.targets).not.toContain(rule.firstParameter.filePath)
-      expect(rule.state.targets).toContain('PortableDocumentFormat.pdf')
-
-      done()
-    })
-  })
-
   describe('run', () => {
     it('copies target to root path.', async (done) => {
       const { rule } = await initialize({
@@ -100,6 +86,7 @@ describe('CopyTargetsToRoot', () => {
 
       expect(await rule.run()).toBeTrue()
       expect(rule.firstParameter.copy).toHaveBeenCalledWith(destination)
+      expect(rule.state.targets).toEqual(['PortableDocumentFormat.pdf'])
 
       done()
     })

--- a/packages/core/spec/Rules/CopyTargetsToRoot_spec.ts
+++ b/packages/core/spec/Rules/CopyTargetsToRoot_spec.ts
@@ -4,6 +4,7 @@
 import * as path from 'path'
 
 import CopyTargetsToRoot from '../../src/Rules/CopyTargetsToRoot'
+import Rule from '../../src/Rule'
 import { initializeRule, RuleDefinition } from '../helpers'
 
 async function initialize ({
@@ -22,8 +23,10 @@ describe('CopyTargetsToRoot', () => {
       const { rule } = await initialize({
         options: { copyTargetsToRoot: true }
       })
+      const otherRule = new Rule(rule.state, 'build', 'execute', rule.options)
 
-      rule.addTarget(rule.firstParameter.filePath)
+      await otherRule.getOutput(rule.firstParameter.filePath, 'target')
+
       expect(await CopyTargetsToRoot.isApplicable(rule, 'build', 'execute', rule.parameters)).toBeTrue()
 
       done()
@@ -36,7 +39,9 @@ describe('CopyTargetsToRoot', () => {
         parameters: [{ filePath }]
       })
 
-      rule.addTarget(filePath)
+      const otherRule = new Rule(rule.state, 'build', 'execute', rule.options)
+
+      await otherRule.getOutput(filePath, 'target')
       expect(await CopyTargetsToRoot.isApplicable(rule, 'build', 'execute', rule.parameters)).toBeFalse()
 
       done()
@@ -49,7 +54,9 @@ describe('CopyTargetsToRoot', () => {
         parameters: [{ filePath }]
       })
 
-      rule.addTarget(filePath)
+      const otherRule = new Rule(rule.state, 'build', 'execute', rule.options)
+
+      await otherRule.getOutput(filePath, 'target')
       expect(await CopyTargetsToRoot.isApplicable(rule, 'build', 'execute', rule.parameters)).toBeFalse()
 
       done()
@@ -68,7 +75,9 @@ describe('CopyTargetsToRoot', () => {
     it('returns false if copyTargetsToRoot is not set', async (done) => {
       const { rule } = await initialize()
 
-      rule.addTarget(rule.firstParameter.filePath)
+      const otherRule = new Rule(rule.state, 'build', 'execute', rule.options)
+
+      await otherRule.getOutput(rule.firstParameter.filePath, 'target')
       expect(await CopyTargetsToRoot.isApplicable(rule, 'build', 'execute', rule.parameters)).toBeFalse()
 
       done()
@@ -83,10 +92,13 @@ describe('CopyTargetsToRoot', () => {
       const destination = path.join(rule.rootPath, 'PortableDocumentFormat.pdf')
 
       spyOn(rule.firstParameter, 'copy')
+      const otherRule = new Rule(rule.state, 'build', 'execute', rule.options)
+
+      await otherRule.getOutput(rule.firstParameter.filePath, 'target')
 
       expect(await rule.run()).toBeTrue()
       expect(rule.firstParameter.copy).toHaveBeenCalledWith(destination)
-      expect(rule.state.targets).toEqual(['PortableDocumentFormat.pdf'])
+      // expect(rule.targets.map(file => file.filePath)).toEqual(['PortableDocumentFormat.pdf'])
 
       done()
     })

--- a/packages/core/spec/Rules/DviToPdf_spec.ts
+++ b/packages/core/spec/Rules/DviToPdf_spec.ts
@@ -59,11 +59,8 @@ describe('DviToPdf', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.pdf'],
-        targets: [{
-          parent: '$FILEPATH_0',
-          filePath: '$DIR_0/$NAME_0.pdf'
-        }]
+        inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.pdf', type: 'target' }]
       })
 
       done()

--- a/packages/core/spec/Rules/DviToPdf_spec.ts
+++ b/packages/core/spec/Rules/DviToPdf_spec.ts
@@ -59,7 +59,11 @@ describe('DviToPdf', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.pdf']
+        outputs: ['$DIR_0/$NAME_0.pdf'],
+        targets: [{
+          parent: '$FILEPATH_0',
+          filePath: '$DIR_0/$NAME_0.pdf'
+        }]
       })
 
       done()

--- a/packages/core/spec/Rules/DviToPs_spec.ts
+++ b/packages/core/spec/Rules/DviToPs_spec.ts
@@ -59,11 +59,8 @@ describe('DviToPs', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.ps'],
-        targets: [{
-          parent: '$FILEPATH_0',
-          filePath: '$DIR_0/$NAME_0.ps'
-        }]
+        inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.ps', type: 'target' }]
       })
 
       done()

--- a/packages/core/spec/Rules/DviToPs_spec.ts
+++ b/packages/core/spec/Rules/DviToPs_spec.ts
@@ -59,7 +59,11 @@ describe('DviToPs', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.ps']
+        outputs: ['$DIR_0/$NAME_0.ps'],
+        targets: [{
+          parent: '$FILEPATH_0',
+          filePath: '$DIR_0/$NAME_0.ps'
+        }]
       })
 
       done()

--- a/packages/core/spec/Rules/DviToSvg_spec.ts
+++ b/packages/core/spec/Rules/DviToSvg_spec.ts
@@ -49,7 +49,11 @@ describe('DviToSvg', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.svg']
+        outputs: ['$DIR_0/$NAME_0.svg'],
+        targets: [{
+          parent: '$FILEPATH_0',
+          filePath: '$DIR_0/$NAME_0.svg'
+        }]
       })
 
       done()

--- a/packages/core/spec/Rules/DviToSvg_spec.ts
+++ b/packages/core/spec/Rules/DviToSvg_spec.ts
@@ -49,11 +49,8 @@ describe('DviToSvg', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.svg'],
-        targets: [{
-          parent: '$FILEPATH_0',
-          filePath: '$DIR_0/$NAME_0.svg'
-        }]
+        inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.svg', type: 'target' }]
       })
 
       done()

--- a/packages/core/spec/Rules/EpsToPdf_spec.ts
+++ b/packages/core/spec/Rules/EpsToPdf_spec.ts
@@ -270,11 +270,8 @@ describe('EpsToPdf', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.pdf'],
-        targets: [{
-          parent: '$FILEPATH_0',
-          filePath: '$DIR_0/$NAME_0.pdf'
-        }]
+        inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.pdf', type: 'target' }]
       })
 
       done()

--- a/packages/core/spec/Rules/EpsToPdf_spec.ts
+++ b/packages/core/spec/Rules/EpsToPdf_spec.ts
@@ -270,7 +270,11 @@ describe('EpsToPdf', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.pdf']
+        outputs: ['$DIR_0/$NAME_0.pdf'],
+        targets: [{
+          parent: '$FILEPATH_0',
+          filePath: '$DIR_0/$NAME_0.pdf'
+        }]
       })
 
       done()

--- a/packages/core/spec/Rules/Knitr_spec.ts
+++ b/packages/core/spec/Rules/Knitr_spec.ts
@@ -22,7 +22,7 @@ describe('Knitr', () => {
         args: ['Rscript', '-e', 'library(knitr);opts_knit$set(concordance=TRUE);knit(\'RNoWeb.Rnw\',\'RNoWeb.tex\')'],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$JOB.tex', '$JOB-concordance.tex']
+        outputs: [{ file: '$JOB.tex' }, { file: '$JOB-concordance.tex' }]
       })
 
       done()
@@ -37,7 +37,7 @@ describe('Knitr', () => {
         args: ['Rscript', '-e', 'library(knitr);knit(\'RNoWeb.Rnw\',\'RNoWeb.tex\')'],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$JOB.tex']
+        outputs: [{ file: '$JOB.tex' }]
       })
 
       done()
@@ -52,7 +52,7 @@ describe('Knitr', () => {
         args: ['Rscript', '-e', 'library(knitr);opts_knit$set(concordance=TRUE);knit(\'RNoWeb.Rnw\',\'foo.tex\')'],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['foo.tex', 'foo-concordance.tex']
+        outputs: [{ file: 'foo.tex' }, { file: 'foo-concordance.tex' }]
       })
 
       done()

--- a/packages/core/spec/Rules/LaTeX_spec.ts
+++ b/packages/core/spec/Rules/LaTeX_spec.ts
@@ -182,18 +182,14 @@ describe('LaTeX', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        inputs: ['$OUTDIR/$JOB.aux'],
+        inputs: [{ file: '$OUTDIR/$JOB.aux' }],
         outputs: [
-          '$OUTDIR/$JOB.aux',
-          '$OUTDIR/$JOB.fls',
-          '$OUTDIR/$JOB.log',
-          '$OUTDIR/$JOB.synctex.gz'
-        ],
-        targets: [{
-          filePath: '$OUTDIR/$JOB$OUTEXT'
-        }, {
-          filePath: '$OUTDIR/$JOB.synctex.gz'
-        }]
+          { file: '$OUTDIR/$JOB.aux' },
+          { file: '$OUTDIR/$JOB.fls' },
+          { file: '$OUTDIR/$JOB.log' },
+          { file: '$OUTDIR/$JOB.synctex.gz', type: 'target' },
+          { file: '$OUTDIR/$JOB$OUTEXT', type: 'target' }
+        ]
       })
 
       done()

--- a/packages/core/spec/Rules/LaTeX_spec.ts
+++ b/packages/core/spec/Rules/LaTeX_spec.ts
@@ -188,7 +188,12 @@ describe('LaTeX', () => {
           '$OUTDIR/$JOB.fls',
           '$OUTDIR/$JOB.log',
           '$OUTDIR/$JOB.synctex.gz'
-        ]
+        ],
+        targets: [{
+          filePath: '$OUTDIR/$JOB$OUTEXT'
+        }, {
+          filePath: '$OUTDIR/$JOB.synctex.gz'
+        }]
       })
 
       done()

--- a/packages/core/spec/Rules/LhsToTeX_spec.ts
+++ b/packages/core/spec/Rules/LhsToTeX_spec.ts
@@ -53,7 +53,7 @@ describe('LhsToTeX', () => {
         args: ['lhs2TeX', '-o', '{{$DIR_0/$NAME_0.tex}}', '{{$FILEPATH_0}}'],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.tex']
+        outputs: [{ file: '$DIR_0/$NAME_0.tex' }]
       })
 
       done()
@@ -69,7 +69,7 @@ describe('LhsToTeX', () => {
         args: ['lhs2TeX', '--agda', '-o', '{{$DIR_0/$NAME_0.tex}}', '{{$FILEPATH_0}}'],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.tex']
+        outputs: [{ file: '$DIR_0/$NAME_0.tex' }]
       })
 
       done()

--- a/packages/core/spec/Rules/MakeGlossaries_spec.ts
+++ b/packages/core/spec/Rules/MakeGlossaries_spec.ts
@@ -22,10 +22,10 @@ describe('MakeGlossaries', () => {
         cd: '$ROOTDIR',
         severity: 'error',
         outputs: [
-          '$DIR_0/$NAME_0.acr',
-          '$DIR_0/$NAME_0.alg',
-          '$DIR_0/$NAME_0.gls',
-          '$DIR_0/$NAME_0.glg'
+          { file: '$DIR_0/$NAME_0.acr' },
+          { file: '$DIR_0/$NAME_0.alg' },
+          { file: '$DIR_0/$NAME_0.gls' },
+          { file: '$DIR_0/$NAME_0.glg' }
         ]
       })
 

--- a/packages/core/spec/Rules/MakeIndex_spec.ts
+++ b/packages/core/spec/Rules/MakeIndex_spec.ts
@@ -471,8 +471,8 @@ describe('MakeIndex', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        inputs: ['$DIR_0/$NAME_0.ilg-ParsedMakeIndexLog'],
-        outputs: ['$DIR_0/$NAME_0.ind', '$DIR_0/$NAME_0.ilg']
+        inputs: [{ file: '$DIR_0/$NAME_0.ilg-ParsedMakeIndexLog' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.ind' }, { file: '$DIR_0/$NAME_0.ilg' }]
       })
 
       done()
@@ -500,8 +500,8 @@ describe('MakeIndex', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        inputs: ['$DIR_0/$NAME_0.nlg-ParsedMakeIndexLog'],
-        outputs: ['$DIR_0/$NAME_0.nls', '$DIR_0/$NAME_0.nlg']
+        inputs: [{ file: '$DIR_0/$NAME_0.nlg-ParsedMakeIndexLog' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.nls' }, { file: '$DIR_0/$NAME_0.nlg' }]
       })
 
       done()
@@ -529,8 +529,8 @@ describe('MakeIndex', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        inputs: ['$DIR_0/$NAME_0.brlg-ParsedMakeIndexLog'],
-        outputs: ['$DIR_0/$NAME_0.bnd', '$DIR_0/$NAME_0.brlg']
+        inputs: [{ file: '$DIR_0/$NAME_0.brlg-ParsedMakeIndexLog' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.bnd' }, { file: '$DIR_0/$NAME_0.brlg' }]
       })
 
       done()

--- a/packages/core/spec/Rules/MetaPost_spec.ts
+++ b/packages/core/spec/Rules/MetaPost_spec.ts
@@ -53,8 +53,11 @@ describe('MetaPost', () => {
         ],
         cd: '$ROOTDIR_0',
         severity: 'error',
-        inputs: ['$DIR_0/$NAME_0.fls-ParsedFileListing'],
-        outputs: ['$DIR_0/$NAME_0.fls', '$DIR_0/$NAME_0.log']
+        inputs: [{ file: '$DIR_0/$NAME_0.fls-ParsedFileListing' }],
+        outputs: [
+          { file: '$DIR_0/$NAME_0.fls' },
+          { file: '$DIR_0/$NAME_0.log' }
+        ]
       })
 
       done()

--- a/packages/core/spec/Rules/PatchSyncTeX_spec.ts
+++ b/packages/core/spec/Rules/PatchSyncTeX_spec.ts
@@ -19,7 +19,7 @@ describe('PatchSyncTeX', () => {
         args: ['Rscript', '-e', 'library(patchSynctex);patchSynctex(\'KnitrConcordance.tex\',syncfile=\'SyncTeX\')'],
         cd: '$ROOTDIR',
         severity: 'warning',
-        outputs: ['$DIR_1/BASE_1']
+        outputs: [{ file: '$DIR_1/BASE_1' }]
       })
 
       done()

--- a/packages/core/spec/Rules/PdfToPs_spec.ts
+++ b/packages/core/spec/Rules/PdfToPs_spec.ts
@@ -48,11 +48,8 @@ describe('PdfToPs', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.ps'],
-        targets: [{
-          parent: '$FILEPATH_0',
-          filePath: '$DIR_0/$NAME_0.ps'
-        }]
+        inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.ps', type: 'target' }]
       })
 
       done()

--- a/packages/core/spec/Rules/PdfToPs_spec.ts
+++ b/packages/core/spec/Rules/PdfToPs_spec.ts
@@ -48,7 +48,11 @@ describe('PdfToPs', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.ps']
+        outputs: ['$DIR_0/$NAME_0.ps'],
+        targets: [{
+          parent: '$FILEPATH_0',
+          filePath: '$DIR_0/$NAME_0.ps'
+        }]
       })
 
       done()

--- a/packages/core/spec/Rules/PsToPdf_spec.ts
+++ b/packages/core/spec/Rules/PsToPdf_spec.ts
@@ -48,11 +48,8 @@ describe('PsToPdf', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.pdf'],
-        targets: [{
-          parent: '$FILEPATH_0',
-          filePath: '$DIR_0/$NAME_0.pdf'
-        }]
+        inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+        outputs: [{ file: '$DIR_0/$NAME_0.pdf', type: 'target' }]
       })
 
       done()

--- a/packages/core/spec/Rules/PsToPdf_spec.ts
+++ b/packages/core/spec/Rules/PsToPdf_spec.ts
@@ -48,7 +48,11 @@ describe('PsToPdf', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$DIR_0/$NAME_0.pdf']
+        outputs: ['$DIR_0/$NAME_0.pdf'],
+        targets: [{
+          parent: '$FILEPATH_0',
+          filePath: '$DIR_0/$NAME_0.pdf'
+        }]
       })
 
       done()

--- a/packages/core/spec/Rules/Pweave_spec.ts
+++ b/packages/core/spec/Rules/Pweave_spec.ts
@@ -32,7 +32,7 @@ describe('Pweave', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['$JOB.tex']
+        outputs: [{ file: '$JOB.tex' }]
       })
 
       done()
@@ -56,7 +56,7 @@ describe('Pweave', () => {
         ],
         cd: '$ROOTDIR',
         severity: 'error',
-        outputs: ['foo.tex']
+        outputs: [{ file: 'foo.tex' }]
       })
 
       done()

--- a/packages/core/spec/Rules/PythonTeX_spec.ts
+++ b/packages/core/spec/Rules/PythonTeX_spec.ts
@@ -21,7 +21,7 @@ describe('PythonTeX', () => {
         args: ['pythontex', '{{$NAME_0}}'],
         cd: '$ROOTDIR_0',
         severity: 'error',
-        globbedOutputs: ['$DIR_0/pythontex-files-$NAME_0/*']
+        globbedOutputs: [{ file: '$DIR_0/pythontex-files-$NAME_0/*' }]
       })
 
       done()

--- a/packages/core/spec/Rules/Sage_spec.ts
+++ b/packages/core/spec/Rules/Sage_spec.ts
@@ -22,12 +22,12 @@ describe('Sage', () => {
         cd: '$ROOTDIR_0',
         severity: 'error',
         outputs: [
-          '$DIR_0/$NAME_0.sout',
-          '$DIR_0/$NAME_0.sage.cmd',
-          '$DIR_0/$NAME_0.scmd',
-          '$FILEPATH_0.py'
+          { file: '$DIR_0/$NAME_0.sout' },
+          { file: '$DIR_0/$NAME_0.sage.cmd' },
+          { file: '$DIR_0/$NAME_0.scmd' },
+          { file: '$FILEPATH_0.py' }
         ],
-        globbedOutputs: ['$DIR_0/sage-plots-for-$JOB.tex/*']
+        globbedInputs: [{ file: '$DIR_0/sage-plots-for-$JOB.tex/*' }]
       })
 
       done()

--- a/packages/core/spec/Rules/SaveCache_spec.ts
+++ b/packages/core/spec/Rules/SaveCache_spec.ts
@@ -69,7 +69,7 @@ describe('SaveCache', () => {
     it('verifies that cache is saved with correct values.', async (done) => {
       const cachePath = path.resolve(__dirname, '..', 'fixtures', 'file-types', 'LaTeX_article-cache.yaml')
       const expectedCache = jasmine.objectContaining({
-        version: '0.10.0',
+        version: '0.13.0',
         filePath: 'LaTeX_article.tex',
         options: jasmine.objectContaining({ engine: 'foo' }),
         files: {
@@ -106,7 +106,10 @@ describe('SaveCache', () => {
           command: 'build',
           phase: 'execute',
           parameters: [],
-          inputs: ['LaTeX_article.tex'],
+          inputs: [{
+            file: 'LaTeX_article.tex',
+            type: 'default'
+          }],
           outputs: []
         }]
       })

--- a/packages/core/spec/Rules/SplitIndex_spec.ts
+++ b/packages/core/spec/Rules/SplitIndex_spec.ts
@@ -119,7 +119,9 @@ describe('SplitIndex', () => {
         args: ['splitindex', '-v', '-v', '-m', '', '{{$FILEPATH_0}}'],
         cd: '$ROOTDIR',
         severity: 'error',
-        inputs: ['$DIR_0/$NAME_0.log-ParsedSplitIndexStdOut'],
+        inputs: [{
+          file: '$DIR_0/$NAME_0.log-ParsedSplitIndexStdOut'
+        }],
         stdout: '$DIR_0/$NAME_0.log-SplitIndexStdOut',
         stderr: '$DIR_0/$NAME_0.log-SplitIndexStdErr'
       })

--- a/packages/core/spec/fixtures/cache-tests/copy-targets-cache.yaml
+++ b/packages/core/spec/fixtures/cache-tests/copy-targets-cache.yaml
@@ -1,4 +1,4 @@
-version: 0.10.0
+version: 0.13.0
 filePath: copy-targets.tex
 options:
   $BIBINPUTS:
@@ -228,7 +228,8 @@ rules:
     phase: initialize
     parameters: []
     inputs:
-      - dicy-instance.yaml-ParsedYAML
+      - file: dicy-instance.yaml-ParsedYAML
+        type: default
     outputs: []
   - name: LoadAndValidateCache
     command: load
@@ -241,28 +242,36 @@ rules:
     phase: execute
     parameters: []
     inputs:
-      - dicy.yaml-ParsedYAML
-      - copy-targets.yaml-ParsedYAML
-      - copy-targets.tex-ParsedLaTeXMagic
-      - dicy-instance.yaml-ParsedYAML
+      - file: dicy.yaml-ParsedYAML
+        type: default
+      - file: copy-targets.yaml-ParsedYAML
+        type: default
+      - file: copy-targets.tex-ParsedLaTeXMagic
+        type: default
+      - file: dicy-instance.yaml-ParsedYAML
+        type: default
     outputs: []
   - name: ParseOptionsFile
     command: load
     phase: execute
     parameters: []
     inputs:
-      - dicy.yaml
+      - file: dicy.yaml
+        type: default
     outputs:
-      - dicy.yaml-ParsedYAML
+      - file: dicy.yaml-ParsedYAML
+        type: default
   - name: ParseLaTeXMagic
     command: load
     phase: execute
     parameters:
       - copy-targets.tex
     inputs:
-      - copy-targets.tex
+      - file: copy-targets.tex
+        type: default
     outputs:
-      - copy-targets.tex-ParsedLaTeXMagic
+      - file: copy-targets.tex-ParsedLaTeXMagic
+        type: default
   - name: AssignJobNames
     command: load
     phase: finalize
@@ -287,51 +296,67 @@ rules:
     parameters:
       - copy-targets.tex
     inputs:
-      - copy-targets.tex
-      - output/copy-targets.fls-ParsedFileListing
-      - output/copy-targets.log-ParsedLaTeXLog
-      - output/copy-targets.aux
+      - file: copy-targets.tex
+        type: default
+      - file: output/copy-targets.fls-ParsedFileListing
+        type: default
+      - file: output/copy-targets.log-ParsedLaTeXLog
+        type: default
+      - file: output/copy-targets.aux
+        type: default
     outputs:
-      - output/copy-targets.aux
-      - output/copy-targets.fls
-      - output/copy-targets.log
-      - output/copy-targets.pdf
+      - file: output/copy-targets.aux
+        type: default
+      - file: output/copy-targets.fls
+        type: default
+      - file: output/copy-targets.log
+        type: default
+      - file: output/copy-targets.pdf
+        type: target
   - name: ParseLaTeXAuxilary
     command: build
     phase: execute
     parameters:
       - output/copy-targets.aux
     inputs:
-      - output/copy-targets.aux
+      - file: output/copy-targets.aux
+        type: default
     outputs:
-      - output/copy-targets.aux-ParsedLaTeXAuxilary
+      - file: output/copy-targets.aux-ParsedLaTeXAuxilary
+        type: default
   - name: ParseFileListing
     command: build
     phase: execute
     parameters:
       - output/copy-targets.fls
     inputs:
-      - output/copy-targets.fls
+      - file: output/copy-targets.fls
+        type: default
     outputs:
-      - output/copy-targets.fls-ParsedFileListing
+      - file: output/copy-targets.fls-ParsedFileListing
+        type: default
   - name: ParseLaTeXLog
     command: build
     phase: execute
     parameters:
       - output/copy-targets.log
     inputs:
-      - output/copy-targets.log
+      - file: output/copy-targets.log
+        type: default
     outputs:
-      - output/copy-targets.log-ParsedLaTeXLog
+      - file: output/copy-targets.log-ParsedLaTeXLog
+        type: default
   - name: CopyTargetsToRoot
     command: build
     phase: execute
     parameters:
       - output/copy-targets.pdf
     inputs:
-      - output/copy-targets.pdf
+      - file: output/copy-targets.pdf
+        type: target
     outputs:
-      - copy-targets.pdf
+      - file: copy-targets.pdf
+        type: target
   - name: LogProducedTargets
     command: build
     phase: finalize
@@ -344,7 +369,8 @@ rules:
     parameters:
       - copy-targets.tex
     inputs:
-      - copy-targets.tex
+      - file: copy-targets.tex
+        type: default
     outputs: []
   - name: SaveCache
     command: save
@@ -364,7 +390,8 @@ rules:
     parameters:
       - output/copy-targets.log-ParsedLaTeXLog
     inputs:
-      - output/copy-targets.log-ParsedLaTeXLog
+      - file: output/copy-targets.log-ParsedLaTeXLog
+        type: default
     outputs: []
   - name: ParseLaTeXLog
     command: log
@@ -372,6 +399,8 @@ rules:
     parameters:
       - output/copy-targets.log
     inputs:
-      - output/copy-targets.log
+      - file: output/copy-targets.log
+        type: default
     outputs:
-      - output/copy-targets.log-ParsedLaTeXLog
+      - file: output/copy-targets.log-ParsedLaTeXLog
+        type: default

--- a/packages/core/spec/helpers.ts
+++ b/packages/core/spec/helpers.ts
@@ -102,11 +102,10 @@ export type RuleDefinition = {
   filePath?: string,
   parameters?: Array<ParameterDefinition>,
   options?: any,
-  targets?: Array<string>,
   clone?: boolean
 }
 
-export async function initializeRule ({ RuleClass, command, phase, jobName, filePath = 'file-types/LaTeX_article.tex', parameters = [], options = {}, targets = [], clone = false }: RuleDefinition) {
+export async function initializeRule ({ RuleClass, command, phase, jobName, filePath = 'file-types/LaTeX_article.tex', parameters = [], options = {}, clone = false }: RuleDefinition) {
   if (!RuleClass) throw new Error('Missing rule class in initializeRule.')
 
   options.loadUserOptions = false
@@ -114,10 +113,6 @@ export async function initializeRule ({ RuleClass, command, phase, jobName, file
   const realFilePath = path.resolve(fixturesPath, filePath)
   const dicy = await Builder.create(realFilePath, options)
   const files: File[] = []
-
-  for (const target of targets) {
-    dicy.addTarget(target)
-  }
 
   for (const { filePath, value } of parameters) {
     const file = await dicy.getFile(filePath)

--- a/packages/core/src/Rule.ts
+++ b/packages/core/src/Rule.ts
@@ -9,6 +9,7 @@ import StateConsumer from './StateConsumer'
 import {
   Action,
   CommandOptions,
+  InputOutputType,
   ParsedLog,
   Phase,
   ProcessResults
@@ -279,16 +280,28 @@ export default class Rule extends StateConsumer {
 
       const result = await this.executeChildProcess(command, options)
 
-      if (commandOptions.inputs) await this.getResolvedInputs(commandOptions.inputs)
+      if (commandOptions.inputs) {
+        for (const dependency of commandOptions.inputs) {
+          await this.getResolvedInput(dependency.file, dependency.type)
+        }
+      }
 
-      if (commandOptions.outputs) await this.getResolvedOutputs(commandOptions.outputs)
+      if (commandOptions.outputs) {
+        for (const dependency of commandOptions.outputs) {
+          await this.getResolvedOutput(dependency.file, dependency.type)
+        }
+      }
 
       if (commandOptions.globbedInputs) {
-        await Promise.all(commandOptions.globbedInputs.map(pattern => this.getGlobbedInputs(pattern)))
+        for (const dependency of commandOptions.globbedInputs) {
+          await this.getGlobbedInputs(dependency.file, dependency.type)
+        }
       }
 
       if (commandOptions.globbedOutputs) {
-        await Promise.all(commandOptions.globbedOutputs.map(pattern => this.getGlobbedOutputs(pattern)))
+        for (const dependency of commandOptions.globbedOutputs) {
+          await this.getGlobbedOutputs(dependency.file, dependency.type)
+        }
       }
 
       if (typeof commandOptions.stdout === 'string') {
@@ -299,12 +312,6 @@ export default class Rule extends StateConsumer {
       if (typeof commandOptions.stderr === 'string') {
         const output = await this.getResolvedOutput(commandOptions.stderr)
         if (output) output.value = result.stderr
-      }
-
-      if (commandOptions.targets) {
-        for (const target of commandOptions.targets) {
-          this.addResolvedTarget(target.filePath, target.parent)
-        }
       }
 
       return result
@@ -330,22 +337,22 @@ export default class Rule extends StateConsumer {
     return true
   }
 
-  async getOutput (filePath: string): Promise<File | undefined> {
+  async getOutput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
     let file: File | undefined = await this.getFile(filePath)
 
     if (file && !this.hasOutput(this, file)) {
-      this.addOutput(this, file)
+      this.addOutput(this, file, type)
       this.trace(`Output added: \`${file.filePath}\``, 'output')
     }
 
     return file
   }
 
-  async getOutputs (filePaths: string[]): Promise<File[]> {
+  async getOutputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
-      const file = await this.getOutput(filePath)
+      const file = await this.getOutput(filePath, type)
       if (file) files.push(file)
     }
 
@@ -360,22 +367,22 @@ export default class Rule extends StateConsumer {
     }
   }
 
-  async getInput (filePath: string): Promise<File | undefined> {
+  async getInput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
     let file: File | undefined = await this.getFile(filePath)
 
     if (file && !this.hasInput(this, file)) {
-      this.addInput(this, file)
+      this.addInput(this, file, type)
       this.trace(`Input added: \`${file.filePath}\``, 'input')
     }
 
     return file
   }
 
-  async getInputs (filePaths: string[]): Promise<File[]> {
+  async getInputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
-      const file = await this.getInput(filePath)
+      const file = await this.getInput(filePath, type)
       if (file) files.push(file)
     }
 
@@ -389,51 +396,51 @@ export default class Rule extends StateConsumer {
     return this.parameters.includes(file)
   }
 
-  async getResolvedInput (filePath: string): Promise<File | undefined> {
+  async getResolvedInput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
     const expanded = this.resolvePath(filePath)
-    return this.getInput(expanded)
+    return this.getInput(expanded, type)
   }
 
-  async getResolvedInputs (filePaths: string[]): Promise<File[]> {
+  async getResolvedInputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
-      const file = await this.getResolvedInput(filePath)
+      const file = await this.getResolvedInput(filePath, type)
       if (file) files.push(file)
     }
 
     return files
   }
 
-  async getResolvedOutput (filePath: string): Promise<File | undefined> {
+  async getResolvedOutput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
     const expanded = this.resolvePath(filePath)
-    return this.getOutput(expanded)
+    return this.getOutput(expanded, type)
   }
 
-  async getResolvedOutputs (filePaths: string[]): Promise<File[]> {
+  async getResolvedOutputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
-      const file = await this.getResolvedOutput(filePath)
+      const file = await this.getResolvedOutput(filePath, type)
       if (file) files.push(file)
     }
 
     return files
   }
 
-  async getGlobbedInputs (pattern: string): Promise<File[]> {
+  async getGlobbedInputs (pattern: string, type?: InputOutputType): Promise<File[]> {
     const files = []
     for (const filePath of await this.globPath(pattern)) {
-      const file = await this.getInput(filePath)
+      const file = await this.getInput(filePath, type)
       if (file) files.push(file)
     }
     return files
   }
 
-  async getGlobbedOutputs (pattern: string): Promise<File[]> {
+  async getGlobbedOutputs (pattern: string, type?: InputOutputType): Promise<File[]> {
     const files = []
     for (const filePath of await this.globPath(pattern)) {
-      const file = await this.getOutput(filePath)
+      const file = await this.getOutput(filePath, type)
       if (file) files.push(file)
     }
     return files

--- a/packages/core/src/Rule.ts
+++ b/packages/core/src/Rule.ts
@@ -9,7 +9,7 @@ import StateConsumer from './StateConsumer'
 import {
   Action,
   CommandOptions,
-  InputOutputType,
+  DependencyType,
   ParsedLog,
   Phase,
   ProcessResults
@@ -337,10 +337,10 @@ export default class Rule extends StateConsumer {
     return true
   }
 
-  async getOutput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
+  async getOutput (filePath: string, type?: DependencyType): Promise<File | undefined> {
     let file: File | undefined = await this.getFile(filePath)
 
-    if (file && !this.hasOutput(this, file)) {
+    if (file && !this.hasOutput(this, file, type)) {
       this.addOutput(this, file, type)
       this.trace(`Output added: \`${file.filePath}\``, 'output')
     }
@@ -348,7 +348,7 @@ export default class Rule extends StateConsumer {
     return file
   }
 
-  async getOutputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
+  async getOutputs (filePaths: string[], type?: DependencyType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
@@ -367,10 +367,10 @@ export default class Rule extends StateConsumer {
     }
   }
 
-  async getInput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
+  async getInput (filePath: string, type?: DependencyType): Promise<File | undefined> {
     let file: File | undefined = await this.getFile(filePath)
 
-    if (file && !this.hasInput(this, file)) {
+    if (file && !this.hasInput(this, file, type)) {
       this.addInput(this, file, type)
       this.trace(`Input added: \`${file.filePath}\``, 'input')
     }
@@ -378,7 +378,7 @@ export default class Rule extends StateConsumer {
     return file
   }
 
-  async getInputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
+  async getInputs (filePaths: string[], type?: DependencyType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
@@ -396,12 +396,12 @@ export default class Rule extends StateConsumer {
     return this.parameters.includes(file)
   }
 
-  async getResolvedInput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
+  async getResolvedInput (filePath: string, type?: DependencyType): Promise<File | undefined> {
     const expanded = this.resolvePath(filePath)
     return this.getInput(expanded, type)
   }
 
-  async getResolvedInputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
+  async getResolvedInputs (filePaths: string[], type?: DependencyType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
@@ -412,12 +412,12 @@ export default class Rule extends StateConsumer {
     return files
   }
 
-  async getResolvedOutput (filePath: string, type?: InputOutputType): Promise<File | undefined> {
+  async getResolvedOutput (filePath: string, type?: DependencyType): Promise<File | undefined> {
     const expanded = this.resolvePath(filePath)
     return this.getOutput(expanded, type)
   }
 
-  async getResolvedOutputs (filePaths: string[], type?: InputOutputType): Promise<File[]> {
+  async getResolvedOutputs (filePaths: string[], type?: DependencyType): Promise<File[]> {
     const files = []
 
     for (const filePath of filePaths) {
@@ -428,7 +428,7 @@ export default class Rule extends StateConsumer {
     return files
   }
 
-  async getGlobbedInputs (pattern: string, type?: InputOutputType): Promise<File[]> {
+  async getGlobbedInputs (pattern: string, type?: DependencyType): Promise<File[]> {
     const files = []
     for (const filePath of await this.globPath(pattern)) {
       const file = await this.getInput(filePath, type)
@@ -437,7 +437,7 @@ export default class Rule extends StateConsumer {
     return files
   }
 
-  async getGlobbedOutputs (pattern: string, type?: InputOutputType): Promise<File[]> {
+  async getGlobbedOutputs (pattern: string, type?: DependencyType): Promise<File[]> {
     const files = []
     for (const filePath of await this.globPath(pattern)) {
       const file = await this.getOutput(filePath, type)

--- a/packages/core/src/Rule.ts
+++ b/packages/core/src/Rule.ts
@@ -301,6 +301,12 @@ export default class Rule extends StateConsumer {
         if (output) output.value = result.stderr
       }
 
+      if (commandOptions.targets) {
+        for (const target of commandOptions.targets) {
+          this.addResolvedTarget(target.filePath, target.parent)
+        }
+      }
+
       return result
     } catch (error) {
       this.log({ severity: commandOptions.severity, text: error.toString(), name: this.constructor.name })

--- a/packages/core/src/Rules/Agda.ts
+++ b/packages/core/src/Rules/Agda.ts
@@ -20,7 +20,11 @@ export default class Agda extends Rule {
       args: ['agda', '--latex', '--latex-dir=.', '{{$BASE_0}}'],
       cd: '$ROOTDIR/$DIR_0',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.tex', '$DIR_0/$NAME_0.agdai', '$DIR_0/agda.sty']
+      outputs: [
+        { file: '$DIR_0/$NAME_0.tex' },
+        { file: '$DIR_0/$NAME_0.agdai' },
+        { file: '$DIR_0/agda.sty' }
+      ]
     }
   }
 }

--- a/packages/core/src/Rules/Asymptote.ts
+++ b/packages/core/src/Rules/Asymptote.ts
@@ -20,13 +20,11 @@ export default class Asymptote extends Rule {
       args: ['asy', '-vv', '{{$BASE_0}}'],
       cd: '$ROOTDIR_0',
       severity: 'error',
-      inputs: [
-        '$DIR_0/$NAME_0.log-ParsedAsymptoteStdOut'
-      ],
+      inputs: [{ file: '$DIR_0/$NAME_0.log-ParsedAsymptoteStdOut' }],
       outputs: [
-        '$DIR_0/${NAME_0}_0.pdf',
-        '$DIR_0/${NAME_0}_0.eps',
-        '$DIR_0/$NAME_0.pre'
+        { file: '$DIR_0/${NAME_0}_0.pdf' },
+        { file: '$DIR_0/${NAME_0}_0.eps' },
+        { file: '$DIR_0/$NAME_0.pre' }
       ],
       stdout: '$DIR_0/$NAME_0.log-AsymptoteStdOut',
       stderr: '$DIR_0/$NAME_0.log-AsymptoteStdErr'

--- a/packages/core/src/Rules/BibTeX.ts
+++ b/packages/core/src/Rules/BibTeX.ts
@@ -65,7 +65,7 @@ export default class BibTeX extends Rule {
       args,
       cd: '$ROOTDIR/$DIR_0',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.bbl', '$DIR_0/$NAME_0.blg']
+      outputs: [{ file: '$DIR_0/$NAME_0.bbl' }, { file: '$DIR_0/$NAME_0.blg' }]
     }
   }
 }

--- a/packages/core/src/Rules/BibToGls.ts
+++ b/packages/core/src/Rules/BibToGls.ts
@@ -40,8 +40,8 @@ export default class BibToGls extends Rule {
       args,
       cd: '$ROOTDIR',
       severity: 'error',
-      inputs: ['$DIR_0/$NAME_0.gelg-ParsedBibToGlsLog'],
-      outputs: ['$DIR_0/$NAME_0.gelg']
+      inputs: [{ file: '$DIR_0/$NAME_0.gelg-ParsedBibToGlsLog' }],
+      outputs: [{ file: '$DIR_0/$NAME_0.gelg' }]
     }
   }
 }

--- a/packages/core/src/Rules/Biber.ts
+++ b/packages/core/src/Rules/Biber.ts
@@ -37,7 +37,7 @@ export default class Biber extends Rule {
       args: ['biber', '{{$FILEPATH_0}}'],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.bbl', '$DIR_0/$NAME_0.blg']
+      outputs: [{ file: '$DIR_0/$NAME_0.bbl' }, { file: '$DIR_0/$NAME_0.blg' }]
     }
   }
 }

--- a/packages/core/src/Rules/CopyTargetsToRoot.ts
+++ b/packages/core/src/Rules/CopyTargetsToRoot.ts
@@ -14,16 +14,15 @@ export default class CopyTargetsToRoot extends Rule {
 
   static async isApplicable (consumer: StateConsumer, command: Command, phase: Phase, parameters: File[] = []): Promise<boolean> {
     return consumer.options.copyTargetsToRoot &&
-      parameters.every(file => !file.virtual && consumer.isFinalTarget(file.filePath) && path.dirname(file.filePath) !== '.')
+      parameters.every(file => !file.virtual && consumer.isOutputTarget(file) && path.dirname(file.filePath) !== '.')
   }
 
   async run () {
     // Copy the target to it's new location and add the result as an output.
     const filePath = this.resolvePath('$ROOTDIR/$BASE_0')
     await this.firstParameter.copy(filePath)
-    await this.getOutput(filePath)
-
-    this.addResolvedTarget('$BASE_0', '$FILEPATH_0')
+    await this.getInput(this.firstParameter.filePath, 'target')
+    await this.getOutput(filePath, 'target')
 
     return true
   }

--- a/packages/core/src/Rules/CopyTargetsToRoot.ts
+++ b/packages/core/src/Rules/CopyTargetsToRoot.ts
@@ -13,14 +13,8 @@ export default class CopyTargetsToRoot extends Rule {
   static alwaysEvaluate: boolean = true
 
   static async isApplicable (consumer: StateConsumer, command: Command, phase: Phase, parameters: File[] = []): Promise<boolean> {
-    return !!consumer.options.copyTargetsToRoot &&
-      parameters.every(file => !file.virtual && consumer.targets.includes(file.filePath) && path.dirname(file.filePath) !== '.')
-  }
-
-  async initialize () {
-    // Remove the old target and replace with the new one.
-    this.removeTarget(this.firstParameter.filePath)
-    this.addResolvedTarget('$BASE_0')
+    return consumer.options.copyTargetsToRoot &&
+      parameters.every(file => !file.virtual && consumer.isFinalTarget(file.filePath) && path.dirname(file.filePath) !== '.')
   }
 
   async run () {
@@ -28,6 +22,9 @@ export default class CopyTargetsToRoot extends Rule {
     const filePath = this.resolvePath('$ROOTDIR/$BASE_0')
     await this.firstParameter.copy(filePath)
     await this.getOutput(filePath)
+
+    this.addResolvedTarget('$BASE_0', '$FILEPATH_0')
+
     return true
   }
 }

--- a/packages/core/src/Rules/DviToPdf.ts
+++ b/packages/core/src/Rules/DviToPdf.ts
@@ -25,11 +25,8 @@ export default class DviToPdf extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.pdf'],
-      targets: [{
-        parent: '$FILEPATH_0',
-        filePath: '$DIR_0/$NAME_0.pdf'
-      }]
+      inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+      outputs: [{ file: '$DIR_0/$NAME_0.pdf', type: 'target' }]
     }
   }
 }

--- a/packages/core/src/Rules/DviToPdf.ts
+++ b/packages/core/src/Rules/DviToPdf.ts
@@ -15,11 +15,6 @@ export default class DviToPdf extends Rule {
     return consumer.options.outputFormat === 'pdf' && !consumer.options.intermediatePostScript
   }
 
-  async initialize () {
-    // Zap the previous target since we are building a pdf
-    await this.replaceResolvedTarget('$FILEPATH_0', '$DIR_0/$NAME_0.pdf')
-  }
-
   constructCommand (): CommandOptions {
     return {
       args: [
@@ -30,7 +25,11 @@ export default class DviToPdf extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.pdf']
+      outputs: ['$DIR_0/$NAME_0.pdf'],
+      targets: [{
+        parent: '$FILEPATH_0',
+        filePath: '$DIR_0/$NAME_0.pdf'
+      }]
     }
   }
 }

--- a/packages/core/src/Rules/DviToPs.ts
+++ b/packages/core/src/Rules/DviToPs.ts
@@ -26,11 +26,8 @@ export default class DviToPs extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.ps'],
-      targets: [{
-        parent: '$FILEPATH_0',
-        filePath: '$DIR_0/$NAME_0.ps'
-      }]
+      inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+      outputs: [{ file: '$DIR_0/$NAME_0.ps', type: 'target' }]
     }
   }
 }

--- a/packages/core/src/Rules/DviToPs.ts
+++ b/packages/core/src/Rules/DviToPs.ts
@@ -16,11 +16,6 @@ export default class DviToPs extends Rule {
       (consumer.options.outputFormat === 'pdf' && !!consumer.options.intermediatePostScript)
   }
 
-  async initialize () {
-    // Zap the previous target since we are building a ps
-    await this.replaceResolvedTarget('$FILEPATH_0', '$DIR_0/$NAME_0.ps')
-  }
-
   constructCommand (): CommandOptions {
     return {
       args: [
@@ -31,7 +26,11 @@ export default class DviToPs extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.ps']
+      outputs: ['$DIR_0/$NAME_0.ps'],
+      targets: [{
+        parent: '$FILEPATH_0',
+        filePath: '$DIR_0/$NAME_0.ps'
+      }]
     }
   }
 }

--- a/packages/core/src/Rules/DviToSvg.ts
+++ b/packages/core/src/Rules/DviToSvg.ts
@@ -24,11 +24,8 @@ export default class DviToSvg extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.svg'],
-      targets: [{
-        parent: '$FILEPATH_0',
-        filePath: '$DIR_0/$NAME_0.svg'
-      }]
+      inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+      outputs: [{ file: '$DIR_0/$NAME_0.svg', type: 'target' }]
     }
   }
 }

--- a/packages/core/src/Rules/DviToSvg.ts
+++ b/packages/core/src/Rules/DviToSvg.ts
@@ -14,11 +14,6 @@ export default class DviToSvg extends Rule {
     return consumer.options.outputFormat === 'svg'
   }
 
-  async initialize () {
-    // Zap the previous target since we are building a svg
-    await this.replaceResolvedTarget('$FILEPATH_0', '$DIR_0/$NAME_0.svg')
-  }
-
   constructCommand (): CommandOptions {
     return {
       args: [
@@ -29,7 +24,11 @@ export default class DviToSvg extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.svg']
+      outputs: ['$DIR_0/$NAME_0.svg'],
+      targets: [{
+        parent: '$FILEPATH_0',
+        filePath: '$DIR_0/$NAME_0.svg'
+      }]
     }
   }
 }

--- a/packages/core/src/Rules/EpsToPdf.ts
+++ b/packages/core/src/Rules/EpsToPdf.ts
@@ -129,11 +129,8 @@ export default class EpsToPdf extends Rule {
       args,
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: [outputPath],
-      targets: [{
-        parent: '$FILEPATH_0',
-        filePath: outputPath
-      }]
+      inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+      outputs: [{ file: outputPath, type: 'target' }]
     }
   }
 }

--- a/packages/core/src/Rules/EpsToPdf.ts
+++ b/packages/core/src/Rules/EpsToPdf.ts
@@ -59,9 +59,7 @@ export default class EpsToPdf extends Rule {
   }
 
   async initialize () {
-    if (this.secondParameter.type === 'Nil') {
-      this.addResolvedTarget('$DIR_0/$NAME_0.pdf')
-    } else {
+    if (this.secondParameter.type !== 'Nil') {
       const call = EpsToPdf.findCall(this.parameters[1].value, this.parameters[0].filePath)
 
       if (call) {
@@ -131,7 +129,11 @@ export default class EpsToPdf extends Rule {
       args,
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: [outputPath]
+      outputs: [outputPath],
+      targets: [{
+        parent: '$FILEPATH_0',
+        filePath: outputPath
+      }]
     }
   }
 }

--- a/packages/core/src/Rules/GraphViz.ts
+++ b/packages/core/src/Rules/GraphViz.ts
@@ -20,7 +20,7 @@ export default class GraphViz extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.$OUTEXT']
+      outputs: [{ file: '$DIR_0/$NAME_0.$OUTEXT' }]
     }
   }
 }

--- a/packages/core/src/Rules/Knitr.ts
+++ b/packages/core/src/Rules/Knitr.ts
@@ -28,7 +28,7 @@ export default class Knitr extends Rule {
       args: ['Rscript', '-e', lines.join(';')],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs
+      outputs: outputs.map(file => ({ file }))
     }
   }
 }

--- a/packages/core/src/Rules/LaTeX.ts
+++ b/packages/core/src/Rules/LaTeX.ts
@@ -31,10 +31,6 @@ export default class LaTeX extends Rule {
       '$OUTDIR/$JOB.fls-ParsedFileListing',
       '$OUTDIR/$JOB.log-ParsedLaTeXLog'
     ])
-    this.addResolvedTargets([
-      '$OUTDIR/$JOB$OUTEXT',
-      '$OUTDIR/$JOB.synctex.gz'
-    ])
   }
 
   async getFileActions (file: File): Promise<Action[]> {
@@ -123,7 +119,12 @@ export default class LaTeX extends Rule {
         '$OUTDIR/$JOB.fls',
         '$OUTDIR/$JOB.log',
         '$OUTDIR/$JOB.synctex.gz'
-      ]
+      ],
+      targets: [{
+        filePath: '$OUTDIR/$JOB$OUTEXT'
+      }, {
+        filePath: '$OUTDIR/$JOB.synctex.gz'
+      }]
     }
   }
 }

--- a/packages/core/src/Rules/LaTeX.ts
+++ b/packages/core/src/Rules/LaTeX.ts
@@ -113,18 +113,14 @@ export default class LaTeX extends Rule {
       args,
       cd: '$ROOTDIR',
       severity: 'error',
-      inputs: ['$OUTDIR/$JOB.aux'],
+      inputs: [{ file: '$OUTDIR/$JOB.aux' }],
       outputs: [
-        '$OUTDIR/$JOB.aux',
-        '$OUTDIR/$JOB.fls',
-        '$OUTDIR/$JOB.log',
-        '$OUTDIR/$JOB.synctex.gz'
-      ],
-      targets: [{
-        filePath: '$OUTDIR/$JOB$OUTEXT'
-      }, {
-        filePath: '$OUTDIR/$JOB.synctex.gz'
-      }]
+        { file: '$OUTDIR/$JOB.aux' },
+        { file: '$OUTDIR/$JOB.fls' },
+        { file: '$OUTDIR/$JOB.log' },
+        { file: '$OUTDIR/$JOB.synctex.gz', type: 'target' },
+        { file: '$OUTDIR/$JOB$OUTEXT', type: 'target' }
+      ]
     }
   }
 }

--- a/packages/core/src/Rules/LhsToTeX.ts
+++ b/packages/core/src/Rules/LhsToTeX.ts
@@ -51,7 +51,7 @@ export default class LhsToTeX extends Rule {
       args,
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.tex']
+      outputs: [{ file: '$DIR_0/$NAME_0.tex' }]
     }
   }
 }

--- a/packages/core/src/Rules/LoadAndValidateCache.ts
+++ b/packages/core/src/Rules/LoadAndValidateCache.ts
@@ -105,7 +105,6 @@ export default class LoadAndValidateCache extends Rule {
     for (const jobName of this.options.jobNames) {
       for (const file of files) {
         await this.deleteFile(file, jobName, false)
-        this.removeTarget(file.filePath)
       }
     }
 

--- a/packages/core/src/Rules/LoadAndValidateCache.ts
+++ b/packages/core/src/Rules/LoadAndValidateCache.ts
@@ -105,7 +105,12 @@ export default class LoadAndValidateCache extends Rule {
     for (const jobName of this.options.jobNames) {
       for (const file of files) {
         await this.deleteFile(file, jobName, false)
+        this.removeTarget(file.filePath)
       }
+    }
+
+    for (const file of this.files) {
+      file.restoreUpdateFlag()
     }
 
     for (const rule of this.rules) {

--- a/packages/core/src/Rules/MakeGlossaries.ts
+++ b/packages/core/src/Rules/MakeGlossaries.ts
@@ -24,10 +24,10 @@ export default class MakeGlossaries extends Rule {
       cd: '$ROOTDIR',
       severity: 'error',
       outputs: [
-        '$DIR_0/$NAME_0.acr',
-        '$DIR_0/$NAME_0.alg',
-        '$DIR_0/$NAME_0.gls',
-        '$DIR_0/$NAME_0.glg'
+        { file: '$DIR_0/$NAME_0.acr' },
+        { file: '$DIR_0/$NAME_0.alg' },
+        { file: '$DIR_0/$NAME_0.gls' },
+        { file: '$DIR_0/$NAME_0.glg' }
       ]
     }
   }

--- a/packages/core/src/Rules/MakeIndex.ts
+++ b/packages/core/src/Rules/MakeIndex.ts
@@ -327,8 +327,8 @@ export default class MakeIndex extends Rule {
       args,
       cd: '$ROOTDIR',
       severity: 'error',
-      inputs: [`${logPath}-${parsedLogName}`],
-      outputs: [outputPath, logPath]
+      inputs: [{ file: `${logPath}-${parsedLogName}` }],
+      outputs: [{ file: outputPath }, { file: logPath }]
     }
 
     if (mendex || upmendex) {

--- a/packages/core/src/Rules/MetaPost.ts
+++ b/packages/core/src/Rules/MetaPost.ts
@@ -23,8 +23,11 @@ export default class MetaPost extends Rule {
       ],
       cd: '$ROOTDIR_0',
       severity: 'error',
-      inputs: ['$DIR_0/$NAME_0.fls-ParsedFileListing'],
-      outputs: ['$DIR_0/$NAME_0.fls', '$DIR_0/$NAME_0.log']
+      inputs: [{ file: '$DIR_0/$NAME_0.fls-ParsedFileListing' }],
+      outputs: [
+        { file: '$DIR_0/$NAME_0.fls' },
+        { file: '$DIR_0/$NAME_0.log' }
+      ]
     }
   }
 }

--- a/packages/core/src/Rules/PatchSyncTeX.ts
+++ b/packages/core/src/Rules/PatchSyncTeX.ts
@@ -32,7 +32,7 @@ export default class PatchSyncTeX extends Rule {
       args: ['Rscript', '-e', lines.join(';')],
       cd: '$ROOTDIR',
       severity: 'warning',
-      outputs: ['$DIR_1/BASE_1']
+      outputs: [{ file: '$DIR_1/BASE_1' }]
     }
   }
 }

--- a/packages/core/src/Rules/PdfToPs.ts
+++ b/packages/core/src/Rules/PdfToPs.ts
@@ -23,11 +23,8 @@ export default class PdfToPs extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.ps'],
-      targets: [{
-        parent: '$FILEPATH_0',
-        filePath: '$DIR_0/$NAME_0.ps'
-      }]
+      inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+      outputs: [{ file: '$DIR_0/$NAME_0.ps', type: 'target' }]
     }
   }
 }

--- a/packages/core/src/Rules/PdfToPs.ts
+++ b/packages/core/src/Rules/PdfToPs.ts
@@ -14,11 +14,6 @@ export default class PdfToPs extends Rule {
     return consumer.options.outputFormat === 'ps'
   }
 
-  async initialize () {
-    // Zap the previous target since we are building a pdf
-    await this.replaceResolvedTarget('$FILEPATH_0', '$DIR_0/$NAME_0.ps')
-  }
-
   constructCommand (): CommandOptions {
     return {
       args: [
@@ -28,7 +23,11 @@ export default class PdfToPs extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.ps']
+      outputs: ['$DIR_0/$NAME_0.ps'],
+      targets: [{
+        parent: '$FILEPATH_0',
+        filePath: '$DIR_0/$NAME_0.ps'
+      }]
     }
   }
 }

--- a/packages/core/src/Rules/PsToPdf.ts
+++ b/packages/core/src/Rules/PsToPdf.ts
@@ -14,11 +14,6 @@ export default class PsToPdf extends Rule {
     return consumer.options.outputFormat === 'pdf'
   }
 
-  async initialize () {
-    // Zap the previous target since we are building a pdf
-    await this.replaceResolvedTarget('$FILEPATH_0', '$DIR_0/$NAME_0.pdf')
-  }
-
   constructCommand (): CommandOptions {
     return {
       args: [
@@ -28,7 +23,11 @@ export default class PsToPdf extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.pdf']
+      outputs: ['$DIR_0/$NAME_0.pdf'],
+      targets: [{
+        parent: '$FILEPATH_0',
+        filePath: '$DIR_0/$NAME_0.pdf'
+      }]
     }
   }
 }

--- a/packages/core/src/Rules/PsToPdf.ts
+++ b/packages/core/src/Rules/PsToPdf.ts
@@ -23,11 +23,8 @@ export default class PsToPdf extends Rule {
       ],
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: ['$DIR_0/$NAME_0.pdf'],
-      targets: [{
-        parent: '$FILEPATH_0',
-        filePath: '$DIR_0/$NAME_0.pdf'
-      }]
+      inputs: [{ file: '$FILEPATH_0', type: 'target' }],
+      outputs: [{ file: '$DIR_0/$NAME_0.pdf', type: 'target' }]
     }
   }
 }

--- a/packages/core/src/Rules/Pweave.ts
+++ b/packages/core/src/Rules/Pweave.ts
@@ -42,7 +42,7 @@ export default class Pweave extends Rule {
       args,
       cd: '$ROOTDIR',
       severity: 'error',
-      outputs: [outputPath]
+      outputs: [{ file: outputPath }]
     }
   }
 }

--- a/packages/core/src/Rules/PythonTeX.ts
+++ b/packages/core/src/Rules/PythonTeX.ts
@@ -11,7 +11,7 @@ export default class PythonTeX extends Rule {
       args: ['pythontex', '{{$NAME_0}}'],
       cd: '$ROOTDIR_0',
       severity: 'error',
-      globbedOutputs: ['$DIR_0/pythontex-files-$NAME_0/*']
+      globbedOutputs: [{ file: '$DIR_0/pythontex-files-$NAME_0/*' }]
     }
   }
 }

--- a/packages/core/src/Rules/Sage.ts
+++ b/packages/core/src/Rules/Sage.ts
@@ -12,12 +12,12 @@ export default class Sage extends Rule {
       cd: '$ROOTDIR_0',
       severity: 'error',
       outputs: [
-        '$DIR_0/$NAME_0.sout',
-        '$DIR_0/$NAME_0.sage.cmd',
-        '$DIR_0/$NAME_0.scmd',
-        '$FILEPATH_0.py'
+        { file: '$DIR_0/$NAME_0.sout' },
+        { file: '$DIR_0/$NAME_0.sage.cmd' },
+        { file: '$DIR_0/$NAME_0.scmd' },
+        { file: '$FILEPATH_0.py' }
       ],
-      globbedOutputs: ['$DIR_0/sage-plots-for-$JOB.tex/*']
+      globbedInputs: [{ file: '$DIR_0/sage-plots-for-$JOB.tex/*' }]
     }
   }
 }

--- a/packages/core/src/Rules/SaveCache.ts
+++ b/packages/core/src/Rules/SaveCache.ts
@@ -66,8 +66,12 @@ export default class SaveCache extends Rule {
         command: rule.command,
         phase: rule.phase,
         parameters: rule.parameters.map(file => file.filePath),
-        inputs: rule.inputs.map(file => file.filePath),
-        outputs: rule.outputs.map(file => file.filePath)
+        inputs: rule.inputs.map(file => {
+          return { file: file.filePath, type: this.state.edge(file.filePath, rule.id) }
+        }),
+        outputs: rule.outputs.map(file => {
+          return { file: file.filePath, type: this.state.edge(rule.id, file.filePath) }
+        })
       }
 
       if (rule.options.jobName) {

--- a/packages/core/src/Rules/SplitIndex.ts
+++ b/packages/core/src/Rules/SplitIndex.ts
@@ -68,7 +68,9 @@ export default class SplitIndex extends Rule {
       args: ['splitindex', '-v', '-v', '-m', '', '{{$FILEPATH_0}}'],
       cd: '$ROOTDIR',
       severity: 'error',
-      inputs: ['$DIR_0/$NAME_0.log-ParsedSplitIndexStdOut'],
+      inputs: [{
+        file: '$DIR_0/$NAME_0.log-ParsedSplitIndexStdOut'
+      }],
       stdout: '$DIR_0/$NAME_0.log-SplitIndexStdOut',
       stderr: '$DIR_0/$NAME_0.log-SplitIndexStdErr'
     }

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -7,7 +7,7 @@ import { Command, OptionDefinition, OptionsInterface } from '@dicy/types'
 import File from './File'
 import Rule from './Rule'
 import {
-  FileCache, InputOutputType, KillToken, OptionInterfaceMap, Phase
+  FileCache, DependencyType, KillToken, OptionInterfaceMap, Phase
 } from './types'
 
 function getLabel (x: File | Rule): string {
@@ -127,12 +127,12 @@ export default class State extends EventEmitter {
     this.graphProperties = {}
   }
 
-  hasInEdge (x: string, type?: InputOutputType): boolean {
+  hasInEdge (x: string, type?: DependencyType): boolean {
     const edges = this.graph.inEdges(x)
     return !!edges && edges.some(edge => !type || this.graph.edge(edge) === type)
   }
 
-  hasOutEdge (x: string, type?: InputOutputType): boolean {
+  hasOutEdge (x: string, type?: DependencyType): boolean {
     const edges = this.graph.outEdges(x)
     return !!edges && edges.some(edge => !type || this.graph.edge(edge) === type)
   }
@@ -141,11 +141,11 @@ export default class State extends EventEmitter {
     return this.graph.hasEdge(x, y)
   }
 
-  edge (x: string, y: string): InputOutputType {
+  edge (x: string, y: string): DependencyType {
     return this.graph.edge(x,y)
   }
 
-  addEdge (x: string, y: string, type?: InputOutputType): void {
+  addEdge (x: string, y: string, type: DependencyType = 'default'): void {
     this.graph.setEdge(x, y, type)
     this.graphProperties = {}
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,6 +89,11 @@ export interface ParsedLog {
   calls: ShellCall[]
 }
 
+export interface Target {
+  filePath: string
+  parent?: string
+}
+
 export interface CommandOptions {
   args: string[]
   cd: string
@@ -99,6 +104,7 @@ export interface CommandOptions {
   globbedOutputs?: string[]
   stdout?: boolean | string
   stderr?: boolean | string
+  targets?: Target[]
 }
 
 export interface ProcessResults {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,7 +37,12 @@ export interface FileCache {
   jobNames?: string[]
 }
 
-export type InputOutputType = 'default' | 'target'
+export type DependencyType = 'default' | 'target'
+
+export interface FileDependency {
+  file: string,
+  type?: DependencyType
+}
 
 export interface RuleCache {
   name: string
@@ -45,8 +50,8 @@ export interface RuleCache {
   phase: Phase
   jobName?: string
   parameters: string[]
-  inputs: string[]
-  outputs: string[]
+  inputs: FileDependency[]
+  outputs: FileDependency[]
 }
 
 export interface Cache {
@@ -57,7 +62,7 @@ export interface Cache {
   rules: RuleCache[]
 }
 
-export const CACHE_VERSION = '0.10.0'
+export const CACHE_VERSION = '0.13.0'
 
 export interface ParserMatch {
   _: string
@@ -89,11 +94,6 @@ export interface ParsedLog {
   outputs: string[]
   messages: Message[]
   calls: ShellCall[]
-}
-
-export interface FileDependency {
-  file: string,
-  type?: InputOutputType
 }
 
 export interface CommandOptions {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,6 +37,8 @@ export interface FileCache {
   jobNames?: string[]
 }
 
+export type InputOutputType = 'default' | 'target'
+
 export interface RuleCache {
   name: string
   command: Command
@@ -89,22 +91,21 @@ export interface ParsedLog {
   calls: ShellCall[]
 }
 
-export interface Target {
-  filePath: string
-  parent?: string
+export interface FileDependency {
+  file: string,
+  type?: InputOutputType
 }
 
 export interface CommandOptions {
   args: string[]
   cd: string
   severity: Severity
-  inputs?: string[]
-  outputs?: string[]
-  globbedInputs?: string[]
-  globbedOutputs?: string[]
+  inputs?: FileDependency[]
+  outputs?: FileDependency[]
+  globbedInputs?: FileDependency[]
+  globbedOutputs?: FileDependency[]
   stdout?: boolean | string
   stderr?: boolean | string
-  targets?: Target[]
 }
 
 export interface ProcessResults {

--- a/scripts/ci-install
+++ b/scripts/ci-install
@@ -6,6 +6,10 @@ if [[ "${APPVEYOR:-}" == true ]]; then
   echo Installing node...
   PowerShell -Command Install-Product node 7 x64
 
+  # TODO: Remove when 'R.Project' package adds it as a dependency.
+  echo Installing chocolatey-core.extension...
+  choco install chocolatey-core.extension
+
   echo Installing GhostScript...
   cinst ghostscript
 


### PR DESCRIPTION
Make `CopyTargetsToRoot` more robust. Allowing for deleted directories, etc.